### PR TITLE
Zefyr forkの残タスク（画像挿入後に改行を入れる）

### DIFF
--- a/packages/notus/lib/src/heuristics/insert_rules.dart
+++ b/packages/notus/lib/src/heuristics/insert_rules.dart
@@ -449,7 +449,6 @@ class InsertEmbedsRule extends InsertRule {
     // We are only interested in embeddable objects.
     if (data is String) return null;
 
-    final dataMap = data as Map<String, dynamic>;
     final result = Delta()..retain(index + replaceLength);
     final iter = DeltaIterator(document);
     final previous = iter.skip(index);
@@ -465,7 +464,7 @@ class InsertEmbedsRule extends InsertRule {
 
     if (isOnEmptyLine) {
       // 画像が挿入された時は改行を追加
-      if (dataMap['_type'] == 'image') {
+      if (Map<String, dynamic>.from(data)['_type'] == 'image') {
         return result..insert(data)..insert('\n');
       }
       return result..insert(data);
@@ -481,7 +480,7 @@ class InsertEmbedsRule extends InsertRule {
       result.insert('\n');
     }
     // 画像が挿入された時は改行を追加
-    if (dataMap['_type'] == 'image') {
+    if (Map<String, dynamic>.from(data)['_type'] == 'image') {
       result.insert('\n');
     }
     return result;

--- a/packages/notus/lib/src/heuristics/insert_rules.dart
+++ b/packages/notus/lib/src/heuristics/insert_rules.dart
@@ -449,6 +449,7 @@ class InsertEmbedsRule extends InsertRule {
     // We are only interested in embeddable objects.
     if (data is String) return null;
 
+    final dataMap = data as Map<String, dynamic>;
     final result = Delta()..retain(index + replaceLength);
     final iter = DeltaIterator(document);
     final previous = iter.skip(index);
@@ -463,6 +464,10 @@ class InsertEmbedsRule extends InsertRule {
     final isOnEmptyLine = isNewlineBefore && isNewlineAfter;
 
     if (isOnEmptyLine) {
+      // 画像が挿入された時は改行を追加
+      if (dataMap['_type'] == 'image') {
+        return result..insert(data)..insert('\n');
+      }
       return result..insert(data);
     }
     // We are on a non-empty line, split it (preserving style if needed)
@@ -473,6 +478,10 @@ class InsertEmbedsRule extends InsertRule {
     }
     result.insert(data);
     if (!isNewlineAfter) {
+      result.insert('\n');
+    }
+    // 画像が挿入された時は改行を追加
+    if (dataMap['_type'] == 'image') {
       result.insert('\n');
     }
     return result;


### PR DESCRIPTION
## 関連Notion
- [Zefyr forkの残タスク（yamamura）](https://www.notion.so/hokuto/Zefyr-fork-yamamura-e364e1afd4fc4898aaacec2fb8d98f77)

## 対応した事
- 画像を挿入すると画像の下に改行が追加されるようにしました

## 今後対応したい事
- 画像の下に改行を追加した後に、選択のフォーカスが画像の手前に留まっていて気持ち悪いので、選択のフォーカスを改行の後ろにズラしたいです
    * 色々と試行錯誤してみましたが、すぐには対処法が分かりそうになかったので、分かる方がいらっしゃったら、教えて頂けると助かりますm(_ _)m

## スクリーンキャプチャ
| 修正前 | 修正後 |
|--|--|
| <video src="https://user-images.githubusercontent.com/55462291/118012330-e3e20a80-b38b-11eb-89d5-7f736d56f995.mov"> | <video src="https://user-images.githubusercontent.com/55462291/118012313-dfb5ed00-b38b-11eb-9926-9ee2fd9ad2e4.mov"> |

## テストした事
- [x] 画像を挿入すると画像の下に改行が追加されている事を確認しました