### PR TITLE
リストの黒丸の位置修正

### DIFF
--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -268,6 +268,7 @@ class _BulletPoint extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      padding: EdgeInsets.only(top: 7),
       alignment: AlignmentDirectional.topCenter,
       width: width,
       child: Container(


### PR DESCRIPTION
# 概要
https://github.com/hokutoresident/zefyr/pull/15 で修正したものが原因で上にずれていた
確認時に再現しなかったのが謎

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-06-09 at 18 42 44](https://user-images.githubusercontent.com/34063746/121332117-80c7a180-c952-11eb-9ac3-b407993a39c7.png)
