### PR TITLE
hokuto appの方で余白タップでの改行が動いてない 

### DIFF
--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -205,4 +205,36 @@ class ZefyrController extends ChangeNotifier {
       composing: TextRange.empty,
     );
   }
+
+  // ノート最後尾に改行を追加
+  void addNewlineAtLast() {
+    replaceText(
+      document.length - 1,
+      0,
+      '\n',
+      selection: selection.copyWith(
+        baseOffset: selection.baseOffset + 1,
+        extentOffset: selection.baseOffset + 1,
+      ),
+    );
+  }
+
+  // ノート最後尾を選択
+  void updateSelectionAtLast() {
+    final lastIndex = document.length - 1;
+    updateSelection(selection.copyWith(
+      baseOffset: lastIndex,
+      extentOffset: lastIndex,
+    ));
+  }
+
+  // ノート最後尾が改行で終わっているか
+  bool isEndNewline() {
+    final wholeText = document.toPlainText();
+    final lastIndex = wholeText.length - 1;
+    final lastChar = wholeText[lastIndex];
+    final secondLastChar = wholeText[lastIndex - 1];
+    final endsNewLine = lastChar == '\n' && secondLastChar == '\n';
+    return endsNewLine;
+  }
 }

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1106,31 +1106,10 @@ class RawEditorState extends EditorState
               GestureDetector(
                 behavior: HitTestBehavior.translucent,
                 onTap: () {
-                  final wholeText = widget.controller.document.toPlainText();
-                  final lastIndex = wholeText.length - 1;
-                  final lastChar = wholeText[lastIndex];
-                  final secondLastChar = wholeText[lastIndex - 1];
-                  final endsNewLine = lastChar == '\n' && secondLastChar == '\n';
-
-                  // 最後が改行で終わってたらそこにカーソルを合わせる
-                  if (endsNewLine) {
-                    final newSelection = widget.controller.selection.copyWith(
-                      baseOffset: wholeText.length - 1,
-                      extentOffset: wholeText.length - 1,
-                    );
-                    widget.controller.updateSelection(newSelection);
-
-                  // そうでなければ改行を追加する
+                  if (widget.controller.isEndNewline()) {
+                    widget.controller.updateSelectionAtLast();
                   } else {
-                    widget.controller.replaceText(
-                      widget.controller.document.length - 1,
-                      0,
-                      '\n',
-                      selection: widget.controller.selection.copyWith(
-                        baseOffset: widget.controller.selection.baseOffset + 1,
-                        extentOffset: widget.controller.selection.baseOffset + 1,
-                      ),
-                    );
+                    widget.controller.addNewlineAtLast();
                   }
                 },
                 child: Container(

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1106,15 +1106,32 @@ class RawEditorState extends EditorState
               GestureDetector(
                 behavior: HitTestBehavior.translucent,
                 onTap: () {
-                  widget.controller.replaceText(
-                    widget.controller.document.length - 1,
-                    0,
-                    '\n',
-                    selection: widget.controller.selection.copyWith(
-                      baseOffset: widget.controller.selection.baseOffset + 1,
-                      extentOffset: widget.controller.selection.baseOffset + 1,
-                    ),
-                  );
+                  final wholeText = widget.controller.document.toPlainText();
+                  final lastIndex = wholeText.length - 1;
+                  final lastChar = wholeText[lastIndex];
+                  final secondLastChar = wholeText[lastIndex - 1];
+                  final endsNewLine = lastChar == '\n' && secondLastChar == '\n';
+
+                  // 最後が改行で終わってたらそこにカーソルを合わせる
+                  if (endsNewLine) {
+                    final newSelection = widget.controller.selection.copyWith(
+                      baseOffset: wholeText.length - 1,
+                      extentOffset: wholeText.length - 1,
+                    );
+                    widget.controller.updateSelection(newSelection);
+
+                  // そうでなければ改行を追加する
+                  } else {
+                    widget.controller.replaceText(
+                      widget.controller.document.length - 1,
+                      0,
+                      '\n',
+                      selection: widget.controller.selection.copyWith(
+                        baseOffset: widget.controller.selection.baseOffset + 1,
+                        extentOffset: widget.controller.selection.baseOffset + 1,
+                      ),
+                    );
+                  }
                 },
                 child: Container(
                   height: 200,

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1084,7 +1084,7 @@ class RawEditorState extends EditorState
       ),
     );
 
-    if (widget.scrollable) {
+    if (widget.scrollable || widget.scrollController != null) {
       /// Since [SingleChildScrollView] does not implement
       /// `computeDistanceToActualBaseline` it prevents the editor from
       /// providing its baseline metrics. To address this issue we wrap

--- a/packages/zefyr/test/widgets/controller_test.dart
+++ b/packages/zefyr/test/widgets/controller_test.dart
@@ -186,5 +186,31 @@ void main() {
       );
       // expect(controller.lastChangeSource, ChangeSource.local);
     });
+    
+    test('addNewlineAtLast', () {
+      controller.replaceText(0, 0, 'words');
+      controller.addNewlineAtLast();
+      expect(
+        controller.document.toDelta(),
+        Delta()..insert('words')..insert('\n')..insert('\n'),
+      );
+    });
+
+    test('updateSelectionAtLast', () {
+      controller.replaceText(0, 0, 'words');
+      controller.updateSelectionAtLast();
+      expect(controller.selection, TextSelection.collapsed(offset: 5));
+    });
+
+    test('isEndNewline true', () {
+      controller.replaceText(0, 0, 'words\n');
+      expect(controller.isEndNewline(), isTrue);
+    });
+
+    test('isEndNewline false', () {
+      controller.replaceText(0, 0, 'words');
+      expect(controller.isEndNewline(), isFalse);
+    });
+
   });
 }


### PR DESCRIPTION
- 以下のPRで、scrollable == falseの時に`overflowed by xxx px`のエラーが出てスクロールできなくなってた問題を修正
- 最後が改行の時はそこにカーソル当たるようにした
- テストケース追加

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=63bd086124a64e54902fc92e27d2e7ea&p=b80fc23b05304b4390e28ff2c2f7e2a5

https://github.com/hokutoresident/zefyr/pull/20
https://github.com/hokutoresident/zefyr/pull/21