### PR TITLE
文字色

### DIFF
--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -380,7 +380,7 @@ class _StrikethroughAttribute extends NotusAttribute<bool> {
 /// Applies accent color style to a text segment.
 class _AccentColorAttribute extends NotusAttribute<String> {
   const _AccentColorAttribute()
-      : super._('ac', NotusAttributeScope.inline, 'FF5555');
+      : super._('ac', NotusAttributeScope.inline, 'FFFFF5555');
 }
 
 /// Builder for link attribute values.

--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -79,7 +79,7 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
     NotusAttribute.italic.key: NotusAttribute.italic,
     NotusAttribute.underline.key: NotusAttribute.underline,
     NotusAttribute.strikethrough.key: NotusAttribute.strikethrough,
-    NotusAttribute.textColor.key: NotusAttribute.textColor,
+    NotusAttribute.accentColor.key: NotusAttribute.accentColor,
     NotusAttribute.link.key: NotusAttribute.link,
     NotusAttribute.heading.key: NotusAttribute.heading,
     NotusAttribute.block.key: NotusAttribute.block,
@@ -99,8 +99,8 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
   /// Strikethrough style attribute.
   static const strikethrough = _StrikethroughAttribute();
 
-  /// text color style attribute.
-  static const textColor = _TextColorAttribute();
+  /// accent color style attribute.
+  static const accentColor = _AccentColorAttribute();
 
   /// Link style attribute.
   // ignore: const_eval_throws_exception
@@ -377,10 +377,10 @@ class _StrikethroughAttribute extends NotusAttribute<bool> {
       : super._('s', NotusAttributeScope.inline, true);
 }
 
-/// Applies text color style to a text segment.
-class _TextColorAttribute extends NotusAttribute<bool> {
-  const _TextColorAttribute()
-      : super._('tc', NotusAttributeScope.inline, true);
+/// Applies accent color style to a text segment.
+class _AccentColorAttribute extends NotusAttribute<String> {
+  const _AccentColorAttribute()
+      : super._('ac', NotusAttributeScope.inline, 'FF5555');
 }
 
 /// Builder for link attribute values.

--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -79,6 +79,7 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
     NotusAttribute.italic.key: NotusAttribute.italic,
     NotusAttribute.underline.key: NotusAttribute.underline,
     NotusAttribute.strikethrough.key: NotusAttribute.strikethrough,
+    NotusAttribute.textColor.key: NotusAttribute.textColor,
     NotusAttribute.link.key: NotusAttribute.link,
     NotusAttribute.heading.key: NotusAttribute.heading,
     NotusAttribute.block.key: NotusAttribute.block,
@@ -97,6 +98,9 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
 
   /// Strikethrough style attribute.
   static const strikethrough = _StrikethroughAttribute();
+
+  /// text color style attribute.
+  static const textColor = _TextColorAttribute();
 
   /// Link style attribute.
   // ignore: const_eval_throws_exception
@@ -371,6 +375,12 @@ class _UnderlineAttribute extends NotusAttribute<bool> {
 class _StrikethroughAttribute extends NotusAttribute<bool> {
   const _StrikethroughAttribute()
       : super._('s', NotusAttributeScope.inline, true);
+}
+
+/// Applies text color style to a text segment.
+class _TextColorAttribute extends NotusAttribute<bool> {
+  const _TextColorAttribute()
+      : super._('tc', NotusAttributeScope.inline, true);
 }
 
 /// Builder for link attribute values.

--- a/packages/notus/test/document/attributes_test.dart
+++ b/packages/notus/test/document/attributes_test.dart
@@ -32,10 +32,10 @@ void main() {
       expect(attr, NotusAttribute.strikethrough);
     });
 
-    test('valid text color', () {
-      final attrs = NotusStyle.fromJson(<String, dynamic>{'tc': true});
-      final attr = attrs.get(NotusAttribute.textColor);
-      expect(attr, NotusAttribute.textColor);
+    test('valid accent color', () {
+      final attrs = NotusStyle.fromJson(<String, dynamic>{'ac': 'FF5555'});
+      final attr = attrs.get(NotusAttribute.accentColor);
+      expect(attr, NotusAttribute.accentColor);
     });
   });
 

--- a/packages/notus/test/document/attributes_test.dart
+++ b/packages/notus/test/document/attributes_test.dart
@@ -33,7 +33,7 @@ void main() {
     });
 
     test('valid accent color', () {
-      final attrs = NotusStyle.fromJson(<String, dynamic>{'ac': 'FF5555'});
+      final attrs = NotusStyle.fromJson(<String, dynamic>{'ac': 'FFFF5555'});
       final attr = attrs.get(NotusAttribute.accentColor);
       expect(attr, NotusAttribute.accentColor);
     });

--- a/packages/notus/test/document/attributes_test.dart
+++ b/packages/notus/test/document/attributes_test.dart
@@ -31,6 +31,12 @@ void main() {
       final attr = attrs.get(NotusAttribute.strikethrough);
       expect(attr, NotusAttribute.strikethrough);
     });
+
+    test('valid text color', () {
+      final attrs = NotusStyle.fromJson(<String, dynamic>{'tc': true});
+      final attr = attrs.get(NotusAttribute.textColor);
+      expect(attr, NotusAttribute.textColor);
+    });
   });
 
   group('$NotusStyle block', () {

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -11,7 +11,7 @@ List<String> _insertionToggleableStyleKeys = [
   NotusAttribute.italic.key,
   NotusAttribute.underline.key,
   NotusAttribute.strikethrough.key,
-  NotusAttribute.textColor.key,
+  NotusAttribute.accentColor.key,
 ];
 
 class ZefyrController extends ChangeNotifier {

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -11,6 +11,7 @@ List<String> _insertionToggleableStyleKeys = [
   NotusAttribute.italic.key,
   NotusAttribute.underline.key,
   NotusAttribute.strikethrough.key,
+  NotusAttribute.textColor.key,
 ];
 
 class ZefyrController extends ChangeNotifier {

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -408,6 +408,14 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       Visibility(
         visible: !hideBoldButton,
         child: ToggleStyleButton(
+          attribute: NotusAttribute.textColor,
+          icon: Icons.format_paint,
+          controller: controller,
+        ),
+      ),
+      Visibility(
+        visible: !hideBoldButton,
+        child: ToggleStyleButton(
           attribute: NotusAttribute.bold,
           icon: Icons.format_bold,
           controller: controller,

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -408,7 +408,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       Visibility(
         visible: !hideBoldButton,
         child: ToggleStyleButton(
-          attribute: NotusAttribute.textColor,
+          attribute: NotusAttribute.accentColor,
           icon: Icons.format_paint,
           controller: controller,
         ),

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -134,8 +134,8 @@ class TextLine extends StatelessWidget {
     if (style.contains(NotusAttribute.strikethrough)) {
       result = _mergeTextStyleWithDecoration(result, theme.strikethrough);
     }
-    if (style.contains(NotusAttribute.textColor)) {
-      result = _mergeTextStyleWithDecoration(result, theme.textColor);
+    if (style.contains(NotusAttribute.accentColor)) {
+      result = _mergeTextStyleWithDecoration(result, theme.accentColor);
     }
 
     return result;

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -134,6 +134,9 @@ class TextLine extends StatelessWidget {
     if (style.contains(NotusAttribute.strikethrough)) {
       result = _mergeTextStyleWithDecoration(result, theme.strikethrough);
     }
+    if (style.contains(NotusAttribute.textColor)) {
+      result = _mergeTextStyleWithDecoration(result, theme.textColor);
+    }
 
     return result;
   }

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -74,8 +74,8 @@ class ZefyrThemeData {
   /// Style of strikethrough text.
   final TextStyle strikethrough;
 
-  /// Style of textcolor text.
-  final TextStyle textColor;
+  /// Style of accentColor text.
+  final TextStyle accentColor;
 
   /// Style of links in text.
   final TextStyle link;
@@ -105,7 +105,7 @@ class ZefyrThemeData {
     this.italic,
     this.underline,
     this.strikethrough,
-    this.textColor,
+    this.accentColor,
     this.link,
     this.paragraph,
     this.heading1,
@@ -125,7 +125,7 @@ class ZefyrThemeData {
       italic: TextStyle(fontStyle: FontStyle.italic),
       underline: TextStyle(decoration: TextDecoration.underline),
       strikethrough: TextStyle(decoration: TextDecoration.lineThrough),
-      textColor: TextStyle(color: Color(0xffFF5555)),
+      accentColor: TextStyle(color: Color(0xffFF5555)),
       link: TextStyle(
         color: themeData.accentColor,
         decoration: TextDecoration.underline,
@@ -218,7 +218,7 @@ class ZefyrThemeData {
     TextStyle italic,
     TextStyle underline,
     TextStyle strikethrough,
-    TextStyle textColor,
+    TextStyle accentColor,
     TextStyle link,
     TextBlockTheme paragraph,
     TextBlockTheme heading1,
@@ -233,7 +233,7 @@ class ZefyrThemeData {
       italic: italic ?? this.italic,
       underline: underline ?? this.underline,
       strikethrough: strikethrough ?? this.strikethrough,
-      textColor: textColor ?? this.textColor,
+      accentColor: accentColor ?? this.accentColor,
       link: link ?? this.link,
       paragraph: paragraph ?? this.paragraph,
       heading1: heading1 ?? this.heading1,
@@ -251,7 +251,7 @@ class ZefyrThemeData {
       italic: other.italic,
       underline: other.underline,
       strikethrough: other.strikethrough,
-      textColor: other.textColor,
+      accentColor: other.accentColor,
       link: other.link,
       paragraph: other.paragraph,
       heading1: other.heading1,

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -125,7 +125,7 @@ class ZefyrThemeData {
       italic: TextStyle(fontStyle: FontStyle.italic),
       underline: TextStyle(decoration: TextDecoration.underline),
       strikethrough: TextStyle(decoration: TextDecoration.lineThrough),
-      textColor: TextStyle(color: Colors.blue),
+      textColor: TextStyle(color: Color(0xffFF5555)),
       link: TextStyle(
         color: themeData.accentColor,
         decoration: TextDecoration.underline,

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -74,6 +74,9 @@ class ZefyrThemeData {
   /// Style of strikethrough text.
   final TextStyle strikethrough;
 
+  /// Style of textcolor text.
+  final TextStyle textColor;
+
   /// Style of links in text.
   final TextStyle link;
 
@@ -102,6 +105,7 @@ class ZefyrThemeData {
     this.italic,
     this.underline,
     this.strikethrough,
+    this.textColor,
     this.link,
     this.paragraph,
     this.heading1,
@@ -121,6 +125,7 @@ class ZefyrThemeData {
       italic: TextStyle(fontStyle: FontStyle.italic),
       underline: TextStyle(decoration: TextDecoration.underline),
       strikethrough: TextStyle(decoration: TextDecoration.lineThrough),
+      textColor: TextStyle(color: Colors.blue),
       link: TextStyle(
         color: themeData.accentColor,
         decoration: TextDecoration.underline,
@@ -213,6 +218,7 @@ class ZefyrThemeData {
     TextStyle italic,
     TextStyle underline,
     TextStyle strikethrough,
+    TextStyle textColor,
     TextStyle link,
     TextBlockTheme paragraph,
     TextBlockTheme heading1,
@@ -227,6 +233,7 @@ class ZefyrThemeData {
       italic: italic ?? this.italic,
       underline: underline ?? this.underline,
       strikethrough: strikethrough ?? this.strikethrough,
+      textColor: textColor ?? this.textColor,
       link: link ?? this.link,
       paragraph: paragraph ?? this.paragraph,
       heading1: heading1 ?? this.heading1,
@@ -244,6 +251,7 @@ class ZefyrThemeData {
       italic: other.italic,
       underline: other.underline,
       strikethrough: other.strikethrough,
+      textColor: other.textColor,
       link: other.link,
       paragraph: other.paragraph,
       heading1: other.heading1,


### PR DESCRIPTION
- `tc`としてtextColorを追加
- 最初は赤のみ(#FF5555)
- 将来的にパレットで他の色も選べるようにするため、linesの中にhex値を入れるようにしないといけないが、現状はlinesに色情報は入れずに、クライアントが固定で赤にしてる

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-06-12 at 19 05 51](https://user-images.githubusercontent.com/34063746/121773210-4e69ae80-cbb5-11eb-9646-f4db98322a21.png)


https://www.notion.so/hokuto/dfacc9824e674b55b8810e8026e6e29e