### PR TITLE
旧Zefyrで作成したノートを編集しようとすると挙動がおかしい

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,0 +1,1 @@
+/Users/son/fvm/versions/2.2.2

--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "2.2.2",
+  "flavors": {}
+}

--- a/packages/notus/lib/notus.dart
+++ b/packages/notus/lib/notus.dart
@@ -16,4 +16,4 @@ export 'src/heuristics.dart';
 export 'src/heuristics/delete_rules.dart';
 export 'src/heuristics/format_rules.dart';
 export 'src/heuristics/insert_rules.dart';
-export 'src/exceptions/unsupported_format.dart';
+export 'src/exceptions/exceptions.dart';

--- a/packages/notus/lib/src/document.dart
+++ b/packages/notus/lib/src/document.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
+import 'package:notus/notus.dart';
 import 'package:quill_delta/quill_delta.dart';
 
 import 'document/attributes.dart';
@@ -250,7 +251,7 @@ class NotusDocument {
     _delta = _delta.compose(change);
 
     if (_delta != _root.toDelta()) {
-      throw StateError('Compose produced inconsistent results. '
+      throw InconsistentDeltaException('Compose produced inconsistent results. '
           'This is likely due to a bug in the library. Tried to compose change $change from $source.');
     }
     _controller.add(NotusChange(before, change, source));

--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'package:collection/collection.dart';
-import 'package:notus/src/exceptions/unsupported_format.dart';
+import 'package:notus/src/exceptions/exceptions.dart';
 import 'package:quiver_hashcode/hashcode.dart';
 
 /// Scope of a style attribute, defines context in which an attribute can be

--- a/packages/notus/lib/src/document/embeds.dart
+++ b/packages/notus/lib/src/document/embeds.dart
@@ -2,7 +2,7 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
-import 'package:notus/src/exceptions/unsupported_format.dart';
+import 'package:notus/src/exceptions/exceptions.dart';
 import 'package:quiver_hashcode/hashcode.dart';
 
 const _dataEquality = DeepCollectionEquality();

--- a/packages/notus/lib/src/exceptions/exceptions.dart
+++ b/packages/notus/lib/src/exceptions/exceptions.dart
@@ -1,0 +1,17 @@
+// 対応してない規格があった場合に投げる
+class UnsupportedFormatException implements Exception {
+  final String message;
+  const UnsupportedFormatException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+// remoteとlocalのdeltaが一致しなかった場合に投げる
+class InconsistentDeltaException implements Exception {
+  final String message;
+  const InconsistentDeltaException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/packages/notus/lib/src/exceptions/unsupported_format.dart
+++ b/packages/notus/lib/src/exceptions/unsupported_format.dart
@@ -1,8 +1,0 @@
-// 対応してない規格があった場合に投げる
-class UnsupportedFormatException implements Exception {
-  final String message;
-  const UnsupportedFormatException(this.message);
-
-  @override
-  String toString() => message;
-}

--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'package:notus/src/exceptions/unsupported_format.dart';
+import 'package:notus/src/exceptions/exceptions.dart';
 
 import 'package:example/src/read_only_view.dart';
 import 'package:file/local.dart';

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   notus:
     git:
       url: https://github.com/hokutoresident/zefyr
-      ref: hokuto
+      ref: feature/inconsistent-delta
       path: packages/notus
   meta: ^1.1.0
   quiver_hashcode: ^2.0.0


### PR DESCRIPTION
compose内で、BlockEmbedとかの規格が旧と新で変わったために起きてたものでした（なので保存すると規格が新しいものに変換されるために次から起きなくなる）

ただの`StateError`だと判別できないので`InconsistentDeltaException`を代わりに投げました
App側でcatchする必要あります

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=32755c3f1d4947dfb381dbdb6906e526