### PR TITLE
ツールバーを左寄せにする

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -284,7 +284,7 @@ Widget defaultToggleStyleButtonBuilder(
 class SelectHeadingStyleButton extends StatefulWidget {
   final ZefyrController controller;
 
-  const SelectHeadingStyleButton({Key key, @required this.controller}) 
+  const SelectHeadingStyleButton({Key key, @required this.controller})
       : super(key: key);
 
   @override
@@ -522,7 +522,8 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
               indent: 16, endIndent: 16, color: Colors.grey.shade400)),
       Visibility(
           visible: !hideLink, child: LinkStyleButton(controller: controller)),
-      Visibility(visible: !hideLink, child: LinkStyleButton(controller: controller)),
+      Visibility(
+          visible: !hideLink, child: LinkStyleButton(controller: controller)),
       Visibility(
         visible: !hideHorizontalRule,
         child: InsertEmbedButton(
@@ -545,15 +546,13 @@ class _ZefyrToolbarState extends State<ZefyrToolbar> {
   Widget build(BuildContext context) {
     return Container(
       constraints: BoxConstraints.tightFor(height: widget.preferredSize.height),
-      child: SingleChildScrollView(
+      child: ListView(
         scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
-            const SizedBox(width: 8),
-            ...widget.children,
-            const SizedBox(width: 8),
-          ],
-        ),
+        children: [
+          const SizedBox(width: 8),
+          ...widget.children,
+          const SizedBox(width: 8),
+        ],
       ),
     );
   }


### PR DESCRIPTION
# 関連プルリク
- [キーボード上メニューのマージンがまだ詰まっておらずキーボードしまうアイコンが見切れている #1031](https://github.com/hokutoresident/hokuto-app/pull/1031)

# アイコンが少ない時のスクリーンショット
| before | after |
| -- | -- |
| <image src="https://user-images.githubusercontent.com/55462291/124446144-1e2fbd00-ddbb-11eb-90ab-bc4e13e466d2.png" width="250"> | <image src="https://user-images.githubusercontent.com/55462291/124446038-03f5df00-ddbb-11eb-8f41-8eae5e5d5a69.png" width="250"> |