### PR TITLE
H2タイトルの上余白が16pt⇒32px にする＋Slackでの指摘

### DIFF
--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -126,7 +126,7 @@ class EditableTextBlock extends StatelessWidget {
     if (block == NotusAttribute.middleHeading) {
       return Divider(
         height: theme.paragraph.style.fontSize * theme.paragraph.style.height,
-        thickness: 2,
+        thickness: 1,
         color: Color(0xFF0099DD),
       );
     }

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -267,8 +267,8 @@ class _ZefyrEditorState extends State<ZefyrEditor>
             selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
         selectionColor = selectionTheme.selectionColor ??
             cupertinoTheme.primaryColor.withOpacity(0.40);
-        selectionColor =
-            selectionTheme.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
+        selectionColor = selectionTheme.selectionColor ??
+            cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(
             iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
@@ -781,7 +781,6 @@ class RawEditorState extends EditorState
     _selectionOverlay?.updateForScroll();
   }
 
-
   // State lifecycle:
 
   @override
@@ -1210,8 +1209,14 @@ class RawEditorState extends EditorState
     } else if (style == NotusAttribute.block.quote) {
       return theme.quote.spacing;
     } else if (style == NotusAttribute.largeHeading) {
+      if (node.isFirst) {
+        return VerticalSpacing(top: 16, bottom: 0);
+      }
       return theme.largeHeading.spacing;
     } else if (style == NotusAttribute.middleHeading) {
+      if (node.isFirst) {
+        return VerticalSpacing(top: 16, bottom: 0);
+      }
       return theme.middleHeading.spacing;
     } else {
       return theme.lists.spacing;

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -244,7 +244,7 @@ class ZefyrThemeData {
           fontSize: 20.0,
           height: 2,
         ),
-        spacing: VerticalSpacing(top: 16, bottom: 0),
+        spacing: VerticalSpacing(top: 32, bottom: 0),
         lineSpacing: VerticalSpacing(top: 0, bottom: 0),
         decoration: BoxDecoration(
           color: Color(0xff0099dd).withAlpha(20),

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -257,7 +257,7 @@ class ZefyrThemeData {
           fontSize: 18.0,
           height: 1.5,
         ),
-        spacing: VerticalSpacing(top: 16, bottom: 0),
+        spacing: VerticalSpacing(top: 24, bottom: 0),
         lineSpacing: VerticalSpacing(top: 0, bottom: 15),
       ),
     );


### PR DESCRIPTION
# 関連Notion
- [H2タイトルの上余白が16pt⇒32px にする＋Slackでの指摘](https://www.notion.so/hokuto/H2-16pt-32px-Slack-53e4b61e01334ca4b2767cd1270d9b27)

# `largeHeading`のスクリーンショット
| before | after |
| -- | -- |
| <image src="https://user-images.githubusercontent.com/55462291/124550016-00219580-de6b-11eb-8677-2ffd2c5f121b.png" width="250"> | <image src="https://user-images.githubusercontent.com/55462291/124549872-c18bdb00-de6a-11eb-92e8-f66df8c88db9.png" width="250"> |

# `middleHeading`のスクリーンショット
| before | after |
| -- | -- |
| <image src="https://user-images.githubusercontent.com/55462291/124550048-0e6fb180-de6b-11eb-9e98-eab4466b5faa.png" width="250"> | <image src="https://user-images.githubusercontent.com/55462291/124549901-d0728d80-de6a-11eb-9958-4aa039ef8ea3.png" width="250"> |
