### PR TITLE
URL入力時は自動でリンク化

### DIFF
--- a/packages/zefyr/example/ios/Podfile.lock
+++ b/packages/zefyr/example/ios/Podfile.lock
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
-  image_picker: 9c3312491f862b28d21ecd8fdf0ee14e601b3f09
+  image_picker: 66aa71bc96850a90590a35d4c4a2907b0d823109
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.0

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -231,7 +231,7 @@ class ZefyrController extends ChangeNotifier {
     replaceText(
       selection.baseOffset,
       0,
-      '\n',
+      ' ',
       selection: selection.copyWith(
         baseOffset: selection.baseOffset + 1,
         extentOffset: selection.baseOffset + 1,

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -231,7 +231,7 @@ class ZefyrController extends ChangeNotifier {
     replaceText(
       selection.baseOffset,
       0,
-      ' ',
+      '\n',
       selection: selection.copyWith(
         baseOffset: selection.baseOffset + 1,
         extentOffset: selection.baseOffset + 1,

--- a/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
+++ b/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
+import 'package:validators/validators.dart';
 import 'package:zefyr/zefyr.dart';
 
 import 'editor.dart';
@@ -53,6 +54,19 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
                 selection: TextSelection.collapsed(
                     offset: selection.start + data.text.length),
               );
+
+              if (isURL(data.text)) {
+                // URLの場合はURLと認識させるために最後尾にスペースを追加する
+                widget.controller.replaceText(
+                  widget.controller.selection.baseOffset,
+                  0,
+                  ' ',
+                  selection: widget.controller.selection.copyWith(
+                    baseOffset: widget.controller.selection.baseOffset + 1,
+                    extentOffset: widget.controller.selection.baseOffset + 1,
+                  ),
+                );
+              }
             }
           }
 

--- a/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
+++ b/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
@@ -57,6 +57,7 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
 
               if (isURL(data.text)) {
                 // URLの場合はURLと認識させるために最後尾にスペースを追加する
+                // NOTE: 一度に `data.text + ' '`のようにreplaceTextしても意味ないので２度更新かけてる
                 widget.controller.replaceText(
                   widget.controller.selection.baseOffset,
                   0,

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   quiver_hashcode: ^2.0.0
   characters: ^1.0.0
   google_fonts: ^2.1.0
+  validators: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
URLは打ち込んだりペーストしてもオートリンクの`AutoFormatLinksRule`は走らなく、最後尾にスペースを一度入れたときにオートリンク処理が発火する
また、`AutoFormatLinksRule`の中で文字自体の加工などはできないので、replaceTextでペーストした直後に追加でスペースを入れている


https://user-images.githubusercontent.com/34063746/125184495-4b67e980-e259-11eb-9112-2a2db45d2ca6.mov


https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=7046a91405394c3d8a64fee1459d7afa