### PR TITLE
囲み枠､各スタイルのデザイン修正

### DIFF
--- a/packages/zefyr/lib/src/rendering/editable_text_line.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_line.dart
@@ -622,8 +622,10 @@ class RenderEditableTextLine extends RenderEditableBox {
 
     if (bottom != null) {
       final bottomConstraints = innerConstraints.copyWith(
-        minWidth: body.size.width + _resolvedPadding.right + _resolvedPadding.left,
-        maxWidth: body.size.width + _resolvedPadding.right + _resolvedPadding.left,
+        minWidth:
+            body.size.width + _resolvedPadding.right + _resolvedPadding.left,
+        maxWidth:
+            body.size.width + _resolvedPadding.right + _resolvedPadding.left,
         maxHeight: body.size.height,
       );
       bottom.layout(bottomConstraints, parentUsesSize: true);
@@ -677,11 +679,9 @@ class RenderEditableTextLine extends RenderEditableBox {
           !_cursorController.style.paintAboveText) {
         _paintCursor(context, effectiveOffset);
       }
-      if (node.style.get(NotusAttribute.block) == NotusAttribute.largeHeading) {
-        context.paintChild(body, effectiveOffset + Offset(0, -4));
-      } else {
-        context.paintChild(body, effectiveOffset);
-      }
+
+      context.paintChild(body, effectiveOffset);
+
       if (hasFocus &&
           _cursorController.showCursor.value &&
           containsCursor &&

--- a/packages/zefyr/lib/src/rendering/editable_text_line.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_line.dart
@@ -622,10 +622,8 @@ class RenderEditableTextLine extends RenderEditableBox {
 
     if (bottom != null) {
       final bottomConstraints = innerConstraints.copyWith(
-        minWidth:
-            body.size.width + _resolvedPadding.right + _resolvedPadding.left,
-        maxWidth:
-            body.size.width + _resolvedPadding.right + _resolvedPadding.left,
+        minWidth: body.size.width + _resolvedPadding.right + _resolvedPadding.left,
+        maxWidth: body.size.width + _resolvedPadding.right + _resolvedPadding.left,
         maxHeight: body.size.height,
       );
       bottom.layout(bottomConstraints, parentUsesSize: true);
@@ -679,9 +677,11 @@ class RenderEditableTextLine extends RenderEditableBox {
           !_cursorController.style.paintAboveText) {
         _paintCursor(context, effectiveOffset);
       }
-
-      context.paintChild(body, effectiveOffset);
-
+      if (node.style.get(NotusAttribute.block) == NotusAttribute.largeHeading) {
+        context.paintChild(body, effectiveOffset + Offset(0, -4));
+      } else {
+        context.paintChild(body, effectiveOffset);
+      }
       if (hasFocus &&
           _cursorController.showCursor.value &&
           containsCursor &&

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -1201,9 +1199,11 @@ class RawEditorState extends EditorState
       return theme.heading2.spacing;
     } else if (style == NotusAttribute.heading.level3) {
       return theme.heading3.spacing;
+    } else if (style == NotusAttribute.caption) {
+      return theme.caption.spacing;
+    } else {
+      return theme.paragraph.spacing;
     }
-
-    return theme.paragraph.spacing;
   }
 
   VerticalSpacing _getSpacingForBlock(BlockNode node, ZefyrThemeData theme) {
@@ -1231,7 +1231,6 @@ class RawEditorState extends EditorState
     final indentValue = node.style.get(NotusAttribute.indent)?.value ?? 0.0;
     return 24.0 * indentValue;
   }
-
 }
 
 class _Editor extends MultiChildRenderObjectWidget {

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -142,7 +142,7 @@ class ZefyrThemeData {
       textColor: TextStyle(color: Color(0xffFF5555)),
       marker: TextStyle(
         decoration: TextDecoration.underline,
-        decorationColor: Color(0x1A0099DD),
+        decorationColor: Color(0xff0099DD).withOpacity(0.15),
         decorationThickness: 10,
       ),
       link: TextStyle(

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -230,7 +230,7 @@ class ZefyrThemeData {
         ),
         spacing: VerticalSpacing(top: 16, bottom: 0),
         decoration: BoxDecoration(
-          color: Color(0xffF1F1F1).withOpacity(0.5),
+          color: Color(0xffF1F1F1).withOpacity(0.8),
           border: Border.all(
             color: Color(0xffF1F1F1),
             width: 1,

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -192,7 +192,7 @@ class ZefyrThemeData {
           color: Color(0xFF999999),
           height: 1.25,
         ),
-        spacing: VerticalSpacing(top: 24.0, bottom: 0.0),
+        spacing: VerticalSpacing(top: 8.0, bottom: 0.0),
       ),
       lists: TextBlockTheme(
         style: TextStyle(

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -242,7 +242,6 @@ class ZefyrThemeData {
           color: Colors.black,
           fontWeight: FontWeight.w700,
           fontSize: 20.0,
-          height: 2,
         ),
         spacing: VerticalSpacing(top: 32, bottom: 0),
         lineSpacing: VerticalSpacing(top: 0, bottom: 0),

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -242,6 +242,7 @@ class ZefyrThemeData {
           color: Colors.black,
           fontWeight: FontWeight.w700,
           fontSize: 20.0,
+          height: 2,
         ),
         spacing: VerticalSpacing(top: 32, bottom: 0),
         lineSpacing: VerticalSpacing(top: 0, bottom: 0),

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -230,7 +230,7 @@ class ZefyrThemeData {
         ),
         spacing: VerticalSpacing(top: 16, bottom: 0),
         decoration: BoxDecoration(
-          color: Color(0xffF1F1F1).withAlpha(50),
+          color: Color(0xffF1F1F1).withOpacity(0.5),
           border: Border.all(
             color: Color(0xffF1F1F1),
             width: 1,


### PR DESCRIPTION
## 関連Notion
- [囲み枠､各スタイルのデザイン修正](https://www.notion.so/hokuto/6c8150ca8fdf431d8b2ab3bf9949cf7b)
    * 見出し：デザインを完璧に再現するのが難しそうだったので、上下のパディングが無い状態でも問題ないか確認中です。
        * もし、見出しに上下のPaddingを付ける方法をご存知の方がいらっしゃいましたら、教えて頂けると助かります。

## スクリーンキャプチャ
| 囲み枠 | マーカー |
| -- | -- |
| <image src="https://user-images.githubusercontent.com/55462291/126903883-f4bc432e-486c-40b0-a536-847059f51d78.png" width="250"> | <image src="https://user-images.githubusercontent.com/55462291/126903862-3e2a1661-de0c-4a1e-8673-44c153f6a4ab.png" width="250"> |

| 注釈 | 見出し |
| -- | -- |
| <image src="https://user-images.githubusercontent.com/55462291/126903910-ffc3c224-8e0b-4c30-86ad-cd7b1bb40675.png" width="250"> | <image src="https://user-images.githubusercontent.com/55462291/126904065-428a3dcf-6059-40d8-b494-b0493bbbc02f.png" width="250"> |