### PR TITLE
見出しと小見出しと注釈が改行時にスタイル残っちゃう

### DIFF
--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -109,6 +109,11 @@ class ZefyrController extends ChangeNotifier {
             source: ChangeSource.local,
           );
         }
+        // selectionにlh, mh, bqが入っている　＆＆　最後が改行ならもう一個改行を足すことで、`AutoExitBlockRule`を適用させてstyleを抜ける
+        final isInMhLhBq = getSelectionStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
+        if (isInMhLhBq && data == '\n') {
+          addNewlineAtSelectionEnd();
+        }
       }
     }
 //    _lastChangeSource = ChangeSource.local;


### PR DESCRIPTION
`AutoExitBlockRule`はblock要素に2連続で`\n`が来たときにスタイルを抜ける。
それを発動させるために`NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq`内で改行したときは更にもう一度改行することで`AutoExitBlockRule`をトリガーし、スタイルを抜けるようにしてます。

`AutoExitBlockRule`をいじるのがより直接的な解決法ですが、そちらで実現できなかったのでこのアプローチでやってます

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=c5c3cb3d5f644498873bbecb3f326242


https://user-images.githubusercontent.com/34063746/130315886-aa303935-dc79-424e-b212-277aa1a8921c.mov


