### PR TITLE
ノートの一部選択がダブルタップでしか出来ないので長押しで一部選択できるようにしたい

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -439,10 +439,7 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
-          renderEditor.selectPositionAt(
-            from: details.globalPosition,
-            cause: SelectionChangedCause.longPress,
-          );
+          renderEditor.selectWord(cause: SelectionChangedCause.longPress);
           break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:


### PR DESCRIPTION
`selectPositionAt`を治すのは骨が折れそうだったので正常に動いている`selectWord`を代用しました

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=30d6c86a05564b428df728420ca5c638


https://user-images.githubusercontent.com/34063746/131204074-ddc38904-4a8f-49b4-8895-43e8f77dd3f8.mov

