### PR TITLE
一行目から二行目にかけての行間だけなにやらおかしいですね。狭い。二行目以降は大丈夫なようです。

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1213,14 +1213,8 @@ class RawEditorState extends EditorState
     } else if (style == NotusAttribute.block.quote) {
       return theme.quote.spacing;
     } else if (style == NotusAttribute.largeHeading) {
-      if (node.isFirst) {
-        return VerticalSpacing(top: 16, bottom: 0);
-      }
       return theme.largeHeading.spacing;
     } else if (style == NotusAttribute.middleHeading) {
-      if (node.isFirst) {
-        return VerticalSpacing(top: 16, bottom: 0);
-      }
       return theme.middleHeading.spacing;
     } else {
       return theme.lists.spacing;


### PR DESCRIPTION
一行目＆＆lh, mhのときにだけ余白がデザイン通りではなかった問題修正

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=c34861c430d64eedb63cd8322477d0fe


|before|after|
|-|-|
|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-28 at 15 51 08](https://user-images.githubusercontent.com/34063746/131209340-764d2e3e-2101-4173-824c-f2cdec48e3e7.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-28 at 15 48 39](https://user-images.githubusercontent.com/34063746/131209279-1093bd3e-a009-4df2-9c44-688ea59bd2dd.png)|

