### PR TITLE
ノート機能で元々マーカー引かれてるところを選択して、マーカー消そうとしても1回目は消えない。2回目で消える。

### DIFF
--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -234,6 +234,13 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
     if (identical(this, other)) return true;
     if (other is! NotusAttribute<T>) return false;
     NotusAttribute<T> typedOther = other;
+
+    // NOTE: 色付きスタイルのhexの差は無視する
+    if ([NotusAttribute.marker.key, NotusAttribute.textColor.key].contains(key)) {
+      return key == typedOther.key &&
+          scope == typedOther.scope;
+    }
+
     return key == typedOther.key &&
         scope == typedOther.scope &&
         value == typedOther.value;


### PR DESCRIPTION
# 概要
- webでつくったマーカーや文字色にカーソルを置いてもスタイルのボタンが活性にならない問題の修正
- 原因はWebとAppのhexの値が違うこと(#があったりなかったり)で、この差によってmarker/textcolorと同一ではないと判定されていた。
- hexの同一性は判定しないようにした
- 将来的に複数色の指定などもできるようになると思うので、その対応にもなっている

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=66b11907ec4d4095adec86452aa05548