### PR TITLE
検索時、該当キーワードがハイライトされているところまで飛ばす

### DIFF
--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -28,7 +28,6 @@ class _HomePageState extends State<HomePage> {
   var _isContainsUnsupportedFormat = false;
 
   String _searchQuery = '';
-  int _searchHitsCount = 0;
 
   void _handleSettingsLoaded(Settings value) {
     setState(() {
@@ -402,21 +401,28 @@ class _HomePageState extends State<HomePage> {
                 onChanged: (query) {
                   setState(() {
                     _searchQuery = query;
-                    _searchHitsCount = _controller.findSearchHitsCount(query);
                   });
                 },
               ),
             ),
             Text(
-              _searchHitsCount.toString(),
+              (_controller.searchFocusIndex == 0 && _searchQuery.isEmpty ? 0 : _controller.searchFocusIndex + 1).toString() + ' / ' + _controller.findSearchMatch(_searchQuery).length.toString(),
             ),
             IconButton(
               icon: Icon(Icons.arrow_downward),
-              onPressed: () {},
+              onPressed: () {
+                setState(() {
+                  _controller.selectNextSearchHit(_searchQuery);
+                });
+              },
             ),
             IconButton(
               icon: Icon(Icons.arrow_upward),
-              onPressed: () {},
+              onPressed: () {
+                setState(() {
+                  _controller.selectPreviousSearchHit(_searchQuery);
+                });
+              },
             ),
           ],
         ),

--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -28,6 +28,7 @@ class _HomePageState extends State<HomePage> {
   var _isContainsUnsupportedFormat = false;
 
   String _searchQuery = '';
+  int _searchHitsCount = 0;
 
   void _handleSettingsLoaded(Settings value) {
     setState(() {
@@ -401,9 +402,13 @@ class _HomePageState extends State<HomePage> {
                 onChanged: (query) {
                   setState(() {
                     _searchQuery = query;
+                    _searchHitsCount = _controller.findSearchHitsCount(query);
                   });
                 },
               ),
+            ),
+            Text(
+              _searchHitsCount.toString(),
             ),
             IconButton(
               icon: Icon(Icons.arrow_downward),

--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -170,17 +170,8 @@ class _HomePageState extends State<HomePage> {
   Widget _buildWelcomeEditor(BuildContext context) {
     return Column(
       children: [
+        _buildSearchBar(context),
         ZefyrToolbar(children: [
-          ZIconButton(
-            size: 32,
-            icon: Icon(
-              Icons.search,
-              size: 18,
-            ),
-            onPressed: () {
-              _showSearchTextField(context);
-            },
-          ),
           ZIconButton(
             highlightElevation: 0,
             hoverElevation: 0,
@@ -394,30 +385,37 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  Future<void> _showSearchTextField(BuildContext context) async {
-    return showDialog(
-        context: context,
-        builder: (context) {
-          return AlertDialog(
-            title: Text('検索'),
-            content: TextFormField(
-              initialValue: _searchQuery,
-              onChanged: (value) {
-                setState(() {
-                  _searchQuery = value;
-                });
-              },
-            ),
-            actions: <Widget>[
-              // ignore: deprecated_member_use
-              FlatButton(
-                onPressed: () {
-                  Navigator.pop(context);
+  Widget _buildSearchBar(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                initialValue: _searchQuery,
+                decoration: const InputDecoration(
+                  hintText: '検索',
+                ),
+                onChanged: (query) {
+                  setState(() {
+                    _searchQuery = query;
+                  });
                 },
-                child: Text('閉じる'),
               ),
-            ],
-          );
-        });
+            ),
+            IconButton(
+              icon: Icon(Icons.arrow_downward),
+              onPressed: () {},
+            ),
+            IconButton(
+              icon: Icon(Icons.arrow_upward),
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -335,7 +335,7 @@ class ZefyrController extends ChangeNotifier {
     if (searchQuery.isEmpty || searchFocusIndex >= total) return;
     searchFocusIndex++;
     final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
-    final next = TextSelection(baseOffset: searchFocus.start, extentOffset: searchFocus.end);
+    final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
     updateSelection(next, source: ChangeSource.local);
     focusStream.sink.add({});
   }
@@ -344,7 +344,7 @@ class ZefyrController extends ChangeNotifier {
     if (searchQuery.isEmpty || searchFocusIndex <= 0) return;
     searchFocusIndex--;
     final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
-    final next = TextSelection(baseOffset: searchFocus.start, extentOffset: searchFocus.end);
+    final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
     updateSelection(next, source: ChangeSource.local);
     focusStream.sink.add({});
   }

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -332,8 +332,12 @@ class ZefyrController extends ChangeNotifier {
 
   void selectNextSearchHit(String searchQuery) {
     final total = findSearchMatch(searchQuery).length;
-    if (searchQuery.isEmpty || searchFocusIndex >= total) return;
-    searchFocusIndex++;
+    if (searchQuery.isEmpty) return;
+    if (searchFocusIndex >= total - 1) {
+      searchFocusIndex = 0;
+    } else {
+      searchFocusIndex++;
+    }
     final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
     final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
     updateSelection(next, source: ChangeSource.local);
@@ -341,8 +345,13 @@ class ZefyrController extends ChangeNotifier {
   }
 
   void selectPreviousSearchHit(String searchQuery) {
-    if (searchQuery.isEmpty || searchFocusIndex <= 0) return;
-    searchFocusIndex--;
+    if (searchQuery.isEmpty) return;
+    if (searchFocusIndex <= 0) {
+      final total = findSearchMatch(searchQuery).length;
+      searchFocusIndex = total - 1;
+    } else {
+      searchFocusIndex--;
+    }
     final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
     final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
     updateSelection(next, source: ChangeSource.local);

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -319,4 +319,9 @@ class ZefyrController extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  int findSearchHitsCount(String searchQuery) {
+    if (searchQuery.isEmpty) return 0;
+    return searchQuery.allMatches(document.toPlainText()).length;
+  }
 }

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -35,7 +35,7 @@ class ZefyrController extends ChangeNotifier {
   NotusStyle _toggledStyles = NotusStyle();
 
   int searchFocusIndex = 0;
-  final focusStream = StreamController<void>();
+  final onChangeSearchFocus = StreamController<void>();
 
   /// Returns style of specified text range.
   ///
@@ -207,7 +207,7 @@ class ZefyrController extends ChangeNotifier {
   @override
   void dispose() {
     document.close();
-    focusStream.close();
+    onChangeSearchFocus.close();
     super.dispose();
   }
 
@@ -341,7 +341,7 @@ class ZefyrController extends ChangeNotifier {
     final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
     final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
     updateSelection(next, source: ChangeSource.local);
-    focusStream.sink.add({});
+    onChangeSearchFocus.sink.add({});
   }
 
   void selectPreviousSearchHit(String searchQuery) {
@@ -355,7 +355,7 @@ class ZefyrController extends ChangeNotifier {
     final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
     final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
     updateSelection(next, source: ChangeSource.local);
-    focusStream.sink.add({});
+    onChangeSearchFocus.sink.add({});
   }
 
 }

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -798,7 +798,7 @@ class RawEditorState extends EditorState
   void initState() {
     super.initState();
 
-    widget.controller.focusStream.stream.listen((_) {
+    widget.controller.onChangeSearchFocus.stream.listen((_) {
       showCaretOnScreen();
     });
 

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -798,6 +798,10 @@ class RawEditorState extends EditorState
   void initState() {
     super.initState();
 
+    widget.controller.focusStream.stream.listen((_) {
+      showCaretOnScreen();
+    });
+
     _clipboardStatus?.addListener(_onChangedClipboardStatus);
 
     widget.controller.addListener(_didChangeTextEditingValue);


### PR DESCRIPTION
- app側実装のための子PRです
- 検索合計ヒット数と現在のフォーカスindexの表示
- 画面外にあった場合はスクロール
- colapse状態になったselectionでないとoffset計算ができずスクロールできないので、一旦は単語の右端のみにカーソルを当てている
- ループするようにしてます


![Simulator Screen Shot - iPhone 8 - 2021-10-29 at 14 16 38](https://user-images.githubusercontent.com/34063746/139379830-1cba101d-acbc-4a20-9b4d-d7b35ceeaa21.png)




https://user-images.githubusercontent.com/34063746/139379825-04516345-63ae-4068-beb0-158ef30334b3.mov




https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=f7da2c323c5f401cba07f175128c1aa3