### PR TITLE
見出し内で改行するとフリーズする不具合の修正

### DIFF
--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -112,13 +112,21 @@ class ZefyrController extends ChangeNotifier {
         // selectionにlh, mh, bqが入っている && 消す対象が改行 && 最後が改行 ならもう一個改行を足すことで、`AutoExitBlockRule`を適用させてstyleを抜ける
         final isInMhLhBq = getSelectionStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
         final selectionEnd = document.toPlainText()[selection.end];
-        if (isInMhLhBq && data == '\n' && selectionEnd == '\n') {
+        final selectionRightIsNotInMhLhBq = !_getCursorRightStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
+        if (isInMhLhBq && data == '\n' && selectionEnd == '\n' && selectionRightIsNotInMhLhBq) {
           addNewlineAtSelectionEnd();
         }
       }
     }
 //    _lastChangeSource = ChangeSource.local;
     notifyListeners();
+  }
+
+  // 現在カーソルのあたってる一個右のスタイル
+  NotusStyle _getCursorRightStyle() {
+    var lineStyle = document.collectStyle(_selection.end + 1, 0);
+    lineStyle = lineStyle.mergeAll(toggledStyles);
+    return lineStyle;
   }
 
   // カーソルの位置を一つ左にずらすべきか否か

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -109,6 +109,7 @@ class ZefyrController extends ChangeNotifier {
             source: ChangeSource.local,
           );
         }
+        // lh, mh, bq内の最後尾でも、一回の改行ではスタイルを抜けることができないため以下の処理をしてる
         // - selectionにlh, mh, bqが入っている &&
         // - 消す対象が改行 &&
         // - 最後が改行 &&

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -109,7 +109,11 @@ class ZefyrController extends ChangeNotifier {
             source: ChangeSource.local,
           );
         }
-        // selectionにlh, mh, bqが入っている && 消す対象が改行 && 最後が改行 ならもう一個改行を足すことで、`AutoExitBlockRule`を適用させてstyleを抜ける
+        // - selectionにlh, mh, bqが入っている &&
+        // - 消す対象が改行 &&
+        // - 最後が改行 &&
+        // - 現在カーソルのあたってる一個右のスタイルがlh, mh, bqではない
+        // ならもう一個改行を足すことで、`AutoExitBlockRule`を適用させてstyleを抜ける
         final isInMhLhBq = getSelectionStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
         final selectionEnd = document.toPlainText()[selection.end];
         final selectionRightIsNotInMhLhBq = !_getCursorRightStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -117,7 +117,7 @@ class ZefyrController extends ChangeNotifier {
         // ならもう一個改行を足すことで、`AutoExitBlockRule`を適用させてstyleを抜ける
         final isInMhLhBq = getSelectionStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
         final selectionEnd = document.toPlainText()[selection.end];
-        final selectionRightIsNotInMhLhBq = !_getCursorRightStyle().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
+        final selectionRightIsNotInMhLhBq = !_getStyleRightOfCurrentCursor().containsAny([NotusAttribute.largeHeading, NotusAttribute.middleHeading, NotusAttribute.bq]);
         if (isInMhLhBq && data == '\n' && selectionEnd == '\n' && selectionRightIsNotInMhLhBq) {
           addNewlineAtSelectionEnd();
         }
@@ -128,7 +128,7 @@ class ZefyrController extends ChangeNotifier {
   }
 
   // 現在カーソルのあたってる一個右のスタイル
-  NotusStyle _getCursorRightStyle() {
+  NotusStyle _getStyleRightOfCurrentCursor() {
     var lineStyle = document.collectStyle(_selection.end + 1, 0);
     lineStyle = lineStyle.mergeAll(toggledStyles);
     return lineStyle;


### PR DESCRIPTION
lh, mh, bqからスタイルを抜ける際、現在カーソルのあたってる一個右のスタイルがlh, mh, bqではない　という条件を足した

https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=660e872ff5a44ebe8dcbc38de928f256

https://user-images.githubusercontent.com/34063746/139535540-41c18910-445b-4eed-9a77-bb2d56cd2e64.mov



