### PR TITLE
編集カーソル(`ZefyrController.selection`)を使わずにハイライトの濃淡で検索時のカーソルを実装し直す

### DIFF
--- a/packages/zefyr/example/ios/Podfile.lock
+++ b/packages/zefyr/example/ios/Podfile.lock
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   image_picker: 66aa71bc96850a90590a35d4c4a2907b0d823109
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef

--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -28,6 +28,7 @@ class _HomePageState extends State<HomePage> {
   var _isContainsUnsupportedFormat = false;
 
   String _searchQuery = '';
+  Match _searchFocus;
 
   void _handleSettingsLoaded(Settings value) {
     setState(() {
@@ -323,6 +324,7 @@ class _HomePageState extends State<HomePage> {
                     // padding: EdgeInsets.only(left: 16, right: 16),
                     onLaunchUrl: _launchUrl,
                     searchQuery: _searchQuery,
+                    searchFocus: _searchFocus,
                   ),
                 ),
         ),
@@ -413,6 +415,8 @@ class _HomePageState extends State<HomePage> {
               onPressed: () {
                 setState(() {
                   _controller.selectNextSearchHit(_searchQuery);
+                  final a = _controller.findSearchMatch(_searchQuery)[_controller.searchFocusIndex];
+                  _searchFocus = a;
                 });
               },
             ),
@@ -421,6 +425,8 @@ class _HomePageState extends State<HomePage> {
               onPressed: () {
                 setState(() {
                   _controller.selectPreviousSearchHit(_searchQuery);
+                  final a = _controller.findSearchMatch(_searchQuery)[_controller.searchFocusIndex];
+                  _searchFocus = a;
                 });
               },
             ),

--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -27,9 +27,6 @@ class _HomePageState extends State<HomePage> {
   Settings _settings;
   var _isContainsUnsupportedFormat = false;
 
-  String _searchQuery = '';
-  Match _searchFocus;
-
   void _handleSettingsLoaded(Settings value) {
     setState(() {
       _settings = value;
@@ -323,8 +320,6 @@ class _HomePageState extends State<HomePage> {
                     // readOnly: true,
                     // padding: EdgeInsets.only(left: 16, right: 16),
                     onLaunchUrl: _launchUrl,
-                    searchQuery: _searchQuery,
-                    searchFocus: _searchFocus,
                   ),
                 ),
         ),
@@ -396,38 +391,34 @@ class _HomePageState extends State<HomePage> {
           children: [
             Expanded(
               child: TextFormField(
-                initialValue: _searchQuery,
+                initialValue: _controller.searchQuery,
                 decoration: const InputDecoration(
                   hintText: '検索',
                 ),
+                onFieldSubmitted: (_) {
+                  _controller.selectNextSearchHit();
+                },
                 onChanged: (query) {
-                  setState(() {
-                    _searchQuery = query;
-                  });
+                  _controller.search(query);
+                  setState(() {});
                 },
               ),
             ),
             Text(
-              (_controller.searchFocusIndex == 0 && _searchQuery.isEmpty ? 0 : _controller.searchFocusIndex + 1).toString() + ' / ' + _controller.findSearchMatch(_searchQuery).length.toString(),
+              (_controller.searchFocusIndex == 0 && _controller.searchQuery.isEmpty ? 0 : _controller.searchFocusIndex + 1).toString() + ' / ' + _controller.findSearchMatch().length.toString(),
             ),
             IconButton(
               icon: Icon(Icons.arrow_downward),
               onPressed: () {
-                setState(() {
-                  _controller.selectNextSearchHit(_searchQuery);
-                  final a = _controller.findSearchMatch(_searchQuery)[_controller.searchFocusIndex];
-                  _searchFocus = a;
-                });
+                _controller.selectNextSearchHit();
+                setState(() {});
               },
             ),
             IconButton(
               icon: Icon(Icons.arrow_upward),
               onPressed: () {
-                setState(() {
-                  _controller.selectPreviousSearchHit(_searchQuery);
-                  final a = _controller.findSearchMatch(_searchQuery)[_controller.searchFocusIndex];
-                  _searchFocus = a;
-                });
+                _controller.selectPreviousSearchHit();
+                setState(() {});
               },
             ),
           ],

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -254,7 +254,7 @@ class RenderEditor extends RenderEditableContainerBox
   }
 
   double getSelectionOffset(double viewportHeight, double scrollOffset, double offsetInViewport, TextSelection selection) {
-    const cursorMargin = 48.0;
+    const cursorMargin = 100.0;
     final endpoints = getEndpointsForSelection(selection);
     if (endpoints.length != 1) return null;
     final child = childAtPosition(selection.extent);

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -254,7 +254,7 @@ class RenderEditor extends RenderEditableContainerBox
   }
 
   double getSelectionOffset(double viewportHeight, double scrollOffset, double offsetInViewport, TextSelection selection) {
-    const cursorMargin = 8.0;
+    const cursorMargin = 48.0;
     final endpoints = getEndpointsForSelection(selection);
     if (endpoints.length != 1) return null;
     final child = childAtPosition(selection.extent);

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -253,6 +253,27 @@ class RenderEditor extends RenderEditableContainerBox
     return null;
   }
 
+  double getSelectionOffset(double viewportHeight, double scrollOffset, double offsetInViewport, TextSelection selection) {
+    const cursorMargin = 8.0;
+    final endpoints = getEndpointsForSelection(selection);
+    if (endpoints.length != 1) return null;
+    final child = childAtPosition(selection.extent);
+    final childPosition = TextPosition(offset: selection.extentOffset - child.node.offset);
+    final caretTop = endpoints.single.point.dy -
+        child.preferredLineHeight(childPosition) -
+        cursorMargin +
+        offsetInViewport;
+    final caretBottom = endpoints.single.point.dy + cursorMargin + offsetInViewport;
+    double dy;
+    if (caretTop < scrollOffset) {
+      dy = caretTop;
+    } else if (caretBottom > scrollOffset + viewportHeight) {
+      dy = caretBottom - viewportHeight;
+    }
+    if (dy == null) return null;
+    return math.max(dy, 0.0);
+  }
+
   @override
   List<TextSelectionPoint> getEndpointsForSelection(TextSelection selection) {
     assert(constraints != null);

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -349,14 +349,8 @@ class ZefyrController extends ChangeNotifier {
     return searchQuery.allMatches(document.toPlainText()).toList();
   }
 
-
-
   void selectFirstSearchHit(String searchQuery) {
-    // if (searchQuery.isEmpty) return;
-    // final searchFocus = findSearchMatch(searchQuery)[0];
-    // final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
-    // updateSelection(next, source: ChangeSource.local);
-    // onChangeSearchFocus.sink.add({});
+    onChangeSearchFocus.sink.add({});
   }
 
   void selectNextSearchHit(String searchQuery) {
@@ -367,10 +361,7 @@ class ZefyrController extends ChangeNotifier {
     } else {
       searchFocusIndex++;
     }
-    // final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
-    // final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
-    // updateSelection(next, source: ChangeSource.local);
-    // onChangeSearchFocus.sink.add({});
+    onChangeSearchFocus.sink.add({});
   }
 
   void selectPreviousSearchHit(String searchQuery) {
@@ -381,9 +372,6 @@ class ZefyrController extends ChangeNotifier {
     } else {
       searchFocusIndex--;
     }
-    // final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
-    // final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
-    // updateSelection(next, source: ChangeSource.local);
-    // onChangeSearchFocus.sink.add({});
+    onChangeSearchFocus.sink.add({});
   }
 }

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -349,12 +349,14 @@ class ZefyrController extends ChangeNotifier {
     return searchQuery.allMatches(document.toPlainText()).toList();
   }
 
+
+
   void selectFirstSearchHit(String searchQuery) {
-    if (searchQuery.isEmpty) return;
-    final searchFocus = findSearchMatch(searchQuery)[0];
-    final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
-    updateSelection(next, source: ChangeSource.local);
-    onChangeSearchFocus.sink.add({});
+    // if (searchQuery.isEmpty) return;
+    // final searchFocus = findSearchMatch(searchQuery)[0];
+    // final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
+    // updateSelection(next, source: ChangeSource.local);
+    // onChangeSearchFocus.sink.add({});
   }
 
   void selectNextSearchHit(String searchQuery) {
@@ -365,10 +367,10 @@ class ZefyrController extends ChangeNotifier {
     } else {
       searchFocusIndex++;
     }
-    final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
-    final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
-    updateSelection(next, source: ChangeSource.local);
-    onChangeSearchFocus.sink.add({});
+    // final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
+    // final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
+    // updateSelection(next, source: ChangeSource.local);
+    // onChangeSearchFocus.sink.add({});
   }
 
   void selectPreviousSearchHit(String searchQuery) {
@@ -379,9 +381,9 @@ class ZefyrController extends ChangeNotifier {
     } else {
       searchFocusIndex--;
     }
-    final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
-    final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
-    updateSelection(next, source: ChangeSource.local);
-    onChangeSearchFocus.sink.add({});
+    // final searchFocus = findSearchMatch(searchQuery)[searchFocusIndex];
+    // final next = TextSelection(baseOffset: searchFocus.end, extentOffset: searchFocus.end);
+    // updateSelection(next, source: ChangeSource.local);
+    // onChangeSearchFocus.sink.add({});
   }
 }

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -34,8 +34,10 @@ class ZefyrController extends ChangeNotifier {
   NotusStyle get toggledStyles => _toggledStyles;
   NotusStyle _toggledStyles = NotusStyle();
 
-  int searchFocusIndex = 0;
-  final onChangeSearchFocus = StreamController<void>();
+  String searchQuery = '';
+  int searchFocusIndex = -1;
+  final onChangeSearchFocus = StreamController<Match>();
+  final onChangeSearchQuery = StreamController<String>();
 
   /// Returns style of specified text range.
   ///
@@ -344,34 +346,44 @@ class ZefyrController extends ChangeNotifier {
     }
   }
 
-  List<Match> findSearchMatch(String searchQuery) {
+  void search(String query) {
+    searchQuery = query;
+    onChangeSearchQuery.sink.add(query);
+  }
+
+  List<Match> findSearchMatch() {
     if (searchQuery.isEmpty) return [];
     return searchQuery.allMatches(document.toPlainText()).toList();
   }
 
-  void selectFirstSearchHit(String searchQuery) {
-    onChangeSearchFocus.sink.add({});
-  }
+  // void selectFirstSearchHit(String searchQuery) {
+  //   if (searchQuery.isEmpty) return;
+  //   searchFocusIndex = 0;
+  //   final focus = findSearchMatch()[searchFocusIndex];
+  //   onChangeSearchFocus.sink.add(focus);
+  // }
 
-  void selectNextSearchHit(String searchQuery) {
-    final total = findSearchMatch(searchQuery).length;
+  void selectNextSearchHit() {
+    final total = findSearchMatch().length;
     if (searchQuery.isEmpty) return;
     if (searchFocusIndex >= total - 1) {
       searchFocusIndex = 0;
     } else {
       searchFocusIndex++;
     }
-    onChangeSearchFocus.sink.add({});
+    final focus = findSearchMatch()[searchFocusIndex];
+    onChangeSearchFocus.sink.add(focus);
   }
 
-  void selectPreviousSearchHit(String searchQuery) {
+  void selectPreviousSearchHit() {
     if (searchQuery.isEmpty) return;
     if (searchFocusIndex <= 0) {
-      final total = findSearchMatch(searchQuery).length;
+      final total = findSearchMatch().length;
       searchFocusIndex = total - 1;
     } else {
       searchFocusIndex--;
     }
-    onChangeSearchFocus.sink.add({});
+    final focus = findSearchMatch()[searchFocusIndex];
+    onChangeSearchFocus.sink.add(focus);
   }
 }

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -356,13 +356,6 @@ class ZefyrController extends ChangeNotifier {
     return searchQuery.allMatches(document.toPlainText()).toList();
   }
 
-  // void selectFirstSearchHit(String searchQuery) {
-  //   if (searchQuery.isEmpty) return;
-  //   searchFocusIndex = 0;
-  //   final focus = findSearchMatch()[searchFocusIndex];
-  //   onChangeSearchFocus.sink.add(focus);
-  // }
-
   void selectNextSearchHit() {
     final total = findSearchMatch().length;
     if (searchQuery.isEmpty) return;

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -24,6 +24,7 @@ class EditableTextBlock extends StatelessWidget {
   final LookupResult lookupResult;
   final Map<int, int> indentLevelCounts;
   final String searchQuery;
+  final Match searchFocus;
 
   EditableTextBlock({
     Key key,
@@ -41,6 +42,7 @@ class EditableTextBlock extends StatelessWidget {
     @required this.lookupResult,
     @required this.indentLevelCounts,
     @required this.searchQuery,
+    this.searchFocus,
   })  : assert(hasFocus != null),
         assert(embedBuilder != null),
         super(key: key);
@@ -82,6 +84,7 @@ class EditableTextBlock extends StatelessWidget {
           inputtingTextRange: inputtingTextRange(line),
           lookupResult: lookupResult,
           searchQuery: searchQuery,
+          searchFocus: searchFocus,
         ),
         cursorController: cursorController,
         selection: selection,

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -185,6 +185,8 @@ class ZefyrEditor extends StatefulWidget {
 
   final String searchQuery;
 
+  final Match searchFocus;
+
   const ZefyrEditor({
     Key key,
     @required this.controller,
@@ -207,6 +209,7 @@ class ZefyrEditor extends StatefulWidget {
     this.onTapEmbedObject,
     this.embedBuilder = defaultZefyrEmbedBuilder,
     this.searchQuery = '',
+    this.searchFocus,
   })  : assert(controller != null),
         super(key: key);
 
@@ -313,6 +316,7 @@ class _ZefyrEditorState extends State<ZefyrEditor>
       onTapEmbedObject: widget.onTapEmbedObject,
       embedBuilder: widget.embedBuilder,
       searchQuery: widget.searchQuery,
+      searchFocus: widget.searchFocus,
       // encapsulated fields below
       cursorStyle: CursorStyle(
         color: cursorColor,
@@ -495,6 +499,7 @@ class RawEditor extends StatefulWidget {
     this.selectionControls,
     this.embedBuilder = defaultZefyrEmbedBuilder,
     this.searchQuery,
+    this.searchFocus,
   })  : assert(controller != null),
         assert(focusNode != null),
         assert(scrollable || scrollController != null),
@@ -652,6 +657,8 @@ class RawEditor extends StatefulWidget {
   final ZefyrEmbedBuilder embedBuilder;
 
   final String searchQuery;
+
+  final Match searchFocus;
 
   bool get selectionEnabled => enableInteractiveSelection;
 
@@ -1179,6 +1186,7 @@ class RawEditorState extends EditorState
             inputtingTextRange: _inputtingTextRange(lookup)(node),
             lookupResult: lookup,
             searchQuery: widget.searchQuery,
+            searchFocus: widget.searchFocus,
           ),
           hasFocus: _hasFocus,
           devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
@@ -1201,6 +1209,7 @@ class RawEditorState extends EditorState
           lookupResult: lookup,
           indentLevelCounts: indentLevelCounts,
           searchQuery: widget.searchQuery,
+          searchFocus: widget.searchFocus,
         ));
       } else {
         throw StateError('Unreachable.');

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -806,7 +806,7 @@ class RawEditorState extends EditorState
     super.initState();
 
     widget.controller.onChangeSearchFocus.stream.listen((_) {
-      showCaretOnScreen();
+      _showSearchFocus();
     });
 
     _clipboardStatus?.addListener(_onChangedClipboardStatus);
@@ -1068,6 +1068,26 @@ class RawEditorState extends EditorState
         );
       }
     });
+  }
+
+  void _showSearchFocus() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    final viewport = RenderAbstractViewport.of(renderEditor);
+    if (viewport == null || widget.searchFocus == null) return;
+    final editorOffset = renderEditor.localToGlobal(Offset(0.0, 0.0), ancestor: viewport);
+    final offsetInViewport = _scrollController.offset + editorOffset.dy;
+    final offset = renderEditor.getSelectionOffset(
+      _scrollController.position.viewportDimension,
+      _scrollController.offset,
+      offsetInViewport,
+      TextSelection(baseOffset: widget.searchFocus.end, extentOffset: widget.searchFocus.end),
+    );
+    if (offset == null) return;
+    await _scrollController.animateTo(
+      offset,
+      duration: _caretAnimationDuration,
+      curve: _caretAnimationCurve,
+    );
   }
 
   void _onChangedClipboardStatus() {

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -21,6 +21,7 @@ class TextLine extends StatelessWidget {
   final TextRange inputtingTextRange;
   final LookupResult lookupResult;
   final String searchQuery;
+  final Match searchFocus;
 
   const TextLine({
     Key key,
@@ -30,6 +31,7 @@ class TextLine extends StatelessWidget {
     this.inputtingTextRange,
     this.lookupResult,
     this.searchQuery,
+    this.searchFocus,
   })  : assert(node != null),
         assert(embedBuilder != null),
         super(key: key);
@@ -75,7 +77,7 @@ class TextLine extends StatelessWidget {
     );
   }
 
-  List<TextSpan> _highlightTextSpans(String source, String query, TextStyle style) {
+  List<TextSpan> _highlightTextSpans(String source, String query, TextStyle style, Node node) {
     if (query == null || query.isEmpty || !source.toLowerCase().contains(query.toLowerCase())) {
       return [ TextSpan(text: source) ];
     }
@@ -93,9 +95,14 @@ class TextLine extends StatelessWidget {
         ));
       }
 
+      final isInThisMatch = match.start + node.documentOffset == searchFocus?.start &&
+          match.end + node.documentOffset == searchFocus?.end;
+      final isInThisTextLine = node.containsOffset(searchFocus?.start ?? -1);
+      final isFocusing = isInThisMatch && isInThisTextLine;
       children.add(TextSpan(
         text: source.substring(match.start, match.end),
-        style: style.copyWith(backgroundColor: Color(0xff0099DD).withOpacity(0.20)),
+        style: style.copyWith(
+            backgroundColor: isFocusing ? Color(0xff0099DD).withOpacity(0.60) : Color(0xff0099DD).withOpacity(0.20)),
       ));
 
       if (i == matches.length - 1 && match.end != source.length) {
@@ -119,7 +126,7 @@ class TextLine extends StatelessWidget {
         return TextSpan(
           children: [
             TextSpan(
-              children: _highlightTextSpans(segment.value, searchQuery, style),
+              children: _highlightTextSpans(segment.value, searchQuery, style, node),
             ),
           ],
           style: _getInlineTextStyle(attrs, theme),
@@ -132,8 +139,7 @@ class TextLine extends StatelessWidget {
           children: [
             TextSpan(text: segment.value.substring(0, textRange.start)),
             TextSpan(
-                text: segment.value
-                    .substring(textRange.start, textRange.end),
+                text: segment.value.substring(textRange.start, textRange.end),
                 style: style.copyWith(backgroundColor: const Color(0x220000FF))),
             TextSpan(
                 text: segment.value


### PR DESCRIPTION
# WHY
- 現状、編集カーソルを使ってスクロールを実現しているが、誤タップによって思いがけない改変を誘発させたり改行ボタンで次の語句にジャンプできない(編集カーソルのため、そのままノートを編集してしまう)という課題がある
- 検索でジャンプするときはマージンが小さすぎてその単語の次の行の文までよめず、結局手動でスクロールする必要がある

# WHAT
- 編集カーソルの代わりに、`searchFocus`を`TextLine`に渡し、ハイライトの濃淡で検索カーソルを実装した
- カーソルを移動させる時、対象が画面外にある場合は自動でそこにスクロールするようにした
- リファクタ
  - `ZefyrEditor`から`searchQuery`と`searchFocus`を変数として渡して外から更新していたのを、`search(String query)`からcontrollerに`searchQuery`を保持してそこからstreamでeditorに渡すようにして検索できるようにした
  - 同じように`selectXxxSearchHit()`も変更した

# DEMO
https://user-images.githubusercontent.com/34063746/143772155-fde34866-3d34-4d4c-afe8-1a4634b8dd8d.mov

# TASK
- [ノート内検索時に編集カーソルの代わりに独自実装の検索カーソルに置き換える](https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=090b35774add4b41b6825a1900212710&p=a40ef2dcbd5545a08f8ac5bbe264614d)
- [ノート内検索P2: 検索カーソルとその移動に伴うスクロールの実装を考える](https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=fee273d5dc1140c0b058f4f3c74ca9e6)
- [検索結果リストを選択した後､ 該当クエリがハイライトされると思うのですが､ キーボードの上ギリギリで結局内容確認するためにスクロールが必要になるので､2枚目の写真ぐらいの位置で表示調整できたりしますか](https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=9acbd05cb1b94d879da17ea1fe793f97&p=ecf14617d5a644d7b12cbe4b0d997ce2)
