### PR TITLE
ひらがな・カタカナを無視して検索ヒットするように

### DIFF
--- a/packages/zefyr/lib/util.dart
+++ b/packages/zefyr/lib/util.dart
@@ -7,6 +7,7 @@ library zefyr.util;
 
 import 'dart:math' as math;
 
+import 'package:kana_kit/kana_kit.dart';
 import 'package:quill_delta/quill_delta.dart';
 
 export 'src/fast_diff.dart';
@@ -48,7 +49,11 @@ List<Match> findMatches(String query, String source) {
 }
 
 extension StringEx on String {
-  String normalized() => toLowerCase();
+  String normalized() {
+    return KanaKit()
+        .copyWithConfig(passKanji: true, passRomaji: true, upcaseKatakana: true)
+        .toKatakana(toLowerCase());
+  }
 
   bool containsMatch(String query) {
     return normalized()

--- a/packages/zefyr/lib/util.dart
+++ b/packages/zefyr/lib/util.dart
@@ -51,7 +51,7 @@ List<Match> findMatches(String query, String source) {
 extension StringEx on String {
   String normalized() {
     return KanaKit()
-        .copyWithConfig(passKanji: true, passRomaji: true, upcaseKatakana: true)
+        .copyWithConfig(passKanji: true, passRomaji: true)
         .toKatakana(toLowerCase());
   }
 

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   characters: ^1.0.0
   google_fonts: ^2.1.0
   validators: ^3.0.0
+  kana_kit: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/zefyr/test/util_test.dart
+++ b/packages/zefyr/test/util_test.dart
@@ -90,13 +90,9 @@ void main() {
         expect('アいウ'.findMatches('アイウ').length, 1);
       });
     });
-    group('mix UPPER CASE, lower case, ひらがな, カタカナ and 漢字', () {
-      test('アいウ equal アイウ', () {
-        expect('アイウ'.findMatches('アいウ').length, 1);
-      });
-      test('アイウ equal アいウ', () {
-        expect('アいウ'.findMatches('アイウ').length, 1);
-      });
+    test('mix UPPER CASE, lower case, ひらがな and カタカナ', () {
+      expect('AbCアいウ'.findMatches('アイウ').length, 1);
+      expect('AbCアいウ'.findMatches('Bc').length, 1);
     });
   });
 }

--- a/packages/zefyr/test/util_test.dart
+++ b/packages/zefyr/test/util_test.dart
@@ -66,5 +66,37 @@ void main() {
         expect('abc'.findMatches('AbC').length, 1);
       });
     });
+    group('find カタカナ in ひらがな', () {
+      test('ア equal あ', () {
+        expect('あいう'.findMatches('ア').length, 1);
+      });
+      test('アイ equal あい', () {
+        expect('あいう'.findMatches('アイ').length, 1);
+      });
+    });
+    group('find ひらがな in カタカナ', () {
+      test('あ equal ア', () {
+        expect('アイウ'.findMatches('あ').length, 1);
+      });
+      test('あい equal アイ', () {
+        expect('アイウ'.findMatches('アイ').length, 1);
+      });
+    });
+    group('mix ひらがな and カタカナ', () {
+      test('アいウ equal アイウ', () {
+        expect('アイウ'.findMatches('アいウ').length, 1);
+      });
+      test('アイウ equal アいウ', () {
+        expect('アいウ'.findMatches('アイウ').length, 1);
+      });
+    });
+    group('mix UPPER CASE, lower case, ひらがな, カタカナ and 漢字', () {
+      test('アいウ equal アイウ', () {
+        expect('アイウ'.findMatches('アいウ').length, 1);
+      });
+      test('アイウ equal アいウ', () {
+        expect('アいウ'.findMatches('アイウ').length, 1);
+      });
+    });
   });
 }


### PR DESCRIPTION
https://www.notion.so/hokuto/5e402562ed614fe691150b7ac8bc9c70?v=090b35774add4b41b6825a1900212710&p=349af2f66a944142b2b0bb7bd965721c

https://user-images.githubusercontent.com/34063746/144077807-389453ed-de19-4e19-8a60-06549baf8e95.mov



