### PR TITLE
onChangeSearchQuery, onChangeSearchFocusのlistenerのclose忘れ

### DIFF
--- a/packages/zefyr/example/ios/Podfile.lock
+++ b/packages/zefyr/example/ios/Podfile.lock
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   image_picker: 66aa71bc96850a90590a35d4c4a2907b0d823109
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
-  url_launcher: b6e016d912f04be9f5bf6e8e82dc599b7ba59649
+  url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -36,8 +36,8 @@ class ZefyrController extends ChangeNotifier {
 
   String searchQuery = '';
   int searchFocusIndex = -1;
-  final onChangeSearchFocus = StreamController<Match>();
-  final onChangeSearchQuery = StreamController<String>();
+  final onChangeSearchFocus = StreamController<Match>.broadcast();
+  final onChangeSearchQuery = StreamController<String>.broadcast();
 
   /// Returns style of specified text range.
   ///

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -922,6 +922,8 @@ class RawEditorState extends EditorState
     _selectionOverlay = null;
     widget.controller.removeListener(_didChangeTextEditingValue);
     widget.focusNode.removeListener(_handleFocusChanged);
+    widget.controller.onChangeSearchFocus.close();
+    widget.controller.onChangeSearchQuery.close();
     _focusAttachment.detach();
     _cursorController.dispose();
     _clipboardStatus?.removeListener(_onChangedClipboardStatus);


### PR DESCRIPTION
- app側で`Bad state: Stream has already been listened to.`が起きていたので`close()`をつけた
- `.broadcast()`に変更