### PR TITLE
feat: add ui exception stream to controller

### DIFF
--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -39,6 +39,8 @@ class ZefyrController extends ChangeNotifier {
   final onChangeSearchFocus = StreamController<Match>.broadcast();
   final onChangeSearchQuery = StreamController<String>.broadcast();
 
+  final uiExceptionStream = StreamController<Object>.broadcast();
+
   String get selectingText => document.toPlainText().substring(selection.baseOffset, selection.extentOffset);
 
   /// Returns style of specified text range.
@@ -230,6 +232,8 @@ class ZefyrController extends ChangeNotifier {
   void dispose() {
     document.close();
     onChangeSearchFocus.close();
+    onChangeSearchQuery.close();
+    uiExceptionStream.close();
     super.dispose();
   }
 

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:notus/notus.dart';
@@ -26,6 +28,8 @@ class EditableTextBlock extends StatelessWidget {
   final String searchQuery;
   final Match? searchFocus;
 
+  final StreamSink<Object> uiExceptionStreamSink;
+
   EditableTextBlock({
     Key? key,
     required this.node,
@@ -43,6 +47,7 @@ class EditableTextBlock extends StatelessWidget {
     required this.searchQuery,
     this.contentPadding,
     this.searchFocus,
+    required this.uiExceptionStreamSink,
   }) : super(key: key);
 
   @override
@@ -75,6 +80,7 @@ class EditableTextBlock extends StatelessWidget {
         bottom: _buildBottom(context, line),
         indentWidth: _styleIndentWidth() + _userIndentWidth(context, line),
         devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
+        uiExceptionStreamSink: uiExceptionStreamSink,
         body: TextLine(
           node: line,
           textDirection: textDirection,

--- a/packages/zefyr/lib/src/widgets/editable_text_line.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_line.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:notus/notus.dart';
 import 'package:zefyr/src/rendering/editable_box.dart';
@@ -37,6 +39,8 @@ class EditableTextLine extends RenderObjectWidget {
   final bool hasFocus;
   final double devicePixelRatio;
 
+  final StreamSink<Object> uiExceptionStreamSink;
+
   /// Creates an editable line of text.
   EditableTextLine({
     Key? key,
@@ -53,6 +57,7 @@ class EditableTextLine extends RenderObjectWidget {
     this.leading,
     this.indentWidth = 0.0,
     this.spacing = const VerticalSpacing(),
+    required this.uiExceptionStreamSink,
   }) : super(key: key);
 
   EdgeInsetsGeometry get _padding => EdgeInsetsDirectional.only(
@@ -133,10 +138,14 @@ class _RenderEditableTextLineElement extends RenderObjectElement {
 
   @override
   void mount(Element? parent, dynamic newSlot) {
-    super.mount(parent, newSlot);
-    _mountChild(widget.bottom, TextLineSlot.bottom);
-    _mountChild(widget.leading, TextLineSlot.leading);
-    _mountChild(widget.body, TextLineSlot.body);
+    try {
+      super.mount(parent, newSlot);
+      _mountChild(widget.bottom, TextLineSlot.bottom);
+      _mountChild(widget.leading, TextLineSlot.leading);
+      _mountChild(widget.body, TextLineSlot.body);
+    } catch (e) {
+      widget.uiExceptionStreamSink.add(e);
+    }
   }
 
   void _updateChild(Widget? widget, TextLineSlot slot) {

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -1190,6 +1192,7 @@ class RawEditorState extends EditorState
           ),
           hasFocus: _hasFocus,
           devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
+          uiExceptionStreamSink: widget.controller.uiExceptionStream.sink,
         ));
       } else if (node is BlockNode) {
         final block = node.style.get(NotusAttribute.block);
@@ -1210,6 +1213,7 @@ class RawEditorState extends EditorState
           indentLevelCounts: indentLevelCounts,
           searchQuery: _searchQuery,
           searchFocus: _searchFocus,
+          uiExceptionStreamSink: widget.controller.uiExceptionStream.sink,
         ));
       } else {
         throw StateError('Unreachable.');


### PR DESCRIPTION
## 🎩 WHY
ノートがグレーアウトする場合の例外をキャッチしたい

## 🌈 WHAT
- `ZefyrController` に例外をキャッチして流す `StreamController` を追加
- Deltaが不正な場合に例外が発生する`EditableTextLine`のmountメソッドで例外をキャッチ

## 🎫 TICKET
- [ノートでグレーアウトする時にエラーメッセージを表示するようにするとともに、エラーログを飛ばすようにする](https://www.notion.so/hokuto/54730fdf9a384a599c8e266233cc81e7)
