### PR TITLE
[After #95] fix: テキストの選択範囲が変更できない不具合を修正

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,0 @@
-/Users/takerusato/fvm/versions/3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 .idea/
 .dart_tool/
+
+#fvm related
+fvm
+.fvm/flutter_sdk

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "dart.flutterSdkPath": ".fvm/flutter_sdk",
+  "dart.sdkPath": ".fvm/flutter_sdk/bin/dart",
   "editor.formatOnSave": false,
   "dart.allowAnalytics": false,
   "dart.enableSdkFormatter": false,

--- a/packages/zefyr/example/android/app/build.gradle
+++ b/packages/zefyr/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.zefyr.example"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/zefyr/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/zefyr/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -14,6 +14,7 @@
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:exported="true"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/packages/zefyr/example/android/build.gradle
+++ b/packages/zefyr/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/zefyr/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/zefyr/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://downloads.gradle-dn.com/distributions/gradle-7.0.2-bin.zip

--- a/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
+++ b/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
@@ -11,8 +11,9 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
 
   @override
   set textEditingValue(TextEditingValue value) {
-    widget.controller
-        .updateSelection(value.selection, source: ChangeSource.local);
+    // NOTE: Flutter 3 から TextSelectionDelegate から
+    // textEditingValue の setter がなくなったので、中身はuserUpdateTextEditingValueで実装する
+    userUpdateTextEditingValue(value, SelectionChangedCause.drag);
   }
 
   @override
@@ -78,7 +79,9 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) async {
-    // NOTE: もはやここは呼ばれないがないと怒られるので
+    // NOTE: causeは今のところ使っていない
+    widget.controller
+        .updateSelection(value.selection, source: ChangeSource.local);
   }
 
   @override

--- a/packages/zefyr/lib/src/widgets/text_selection.dart
+++ b/packages/zefyr/lib/src/widgets/text_selection.dart
@@ -356,21 +356,29 @@ class EditorTextSelectionOverlay {
 
   void _handleSelectionHandleChanged(
       TextSelection newSelection, _TextSelectionHandlePosition position) {
-    late TextPosition textPosition;
-    switch (position) {
-      case _TextSelectionHandlePosition.start:
-        textPosition = newSelection.base;
-        break;
-      case _TextSelectionHandlePosition.end:
-        textPosition = newSelection.extent;
-        break;
-    }
-    // ignore: deprecated_member_use
+
+    // bringIntoView がいまのところ実装されていないためコメントアウト
+    // late TextPosition textPosition;
+    // switch (position) {
+    //   case _TextSelectionHandlePosition.start:
+    //     textPosition = newSelection.base;
+    //     break;
+    //   case _TextSelectionHandlePosition.end:
+    //     textPosition = newSelection.extent;
+    //     break;
+    // }
+
+    // 長さが0になる場合に挙動が不安定なので、最低1は確保するようにする
+    final selection = newSelection.baseOffset == newSelection.extentOffset ?
+    newSelection.copyWith(extentOffset: newSelection.extentOffset + 1) : newSelection;
+
     selectionDelegate!.userUpdateTextEditingValue(
-      _value.copyWith(selection: newSelection, composing: TextRange.empty),
+      _value.copyWith(selection: selection, composing: TextRange.empty),
       SelectionChangedCause.keyboard,
     );
-    selectionDelegate!.bringIntoView(textPosition);
+
+    // bringIntoView はいまのところ実装されていない
+    // selectionDelegate!.bringIntoView(textPosition);
   }
 }
 


### PR DESCRIPTION
# Part1
## Why
テキストの選択範囲の変更時に呼ばれるメソッドが実装されていなかったため、選択範囲の変更が反映されていなかった

## What
- userUpdateTextEditingValue を実装 aa841cf1515d8234cadb1ca8a416c6deac07b2f5

# Part2
## Why
選択範囲の長さが0またはマイナスになったときの挙動が怪しい

## What
- 選択範囲の長さが最低1になるように変更 59a126a6e06bd8e222307d18a0fa47824135f961
  - ベストの挙動ではないかもしれませんが、一旦これで……

## Demo
|before|after|
|--|--|
|https://user-images.githubusercontent.com/10044588/177236319-6845776c-04b7-4650-8af7-01c7b62ae014.mp4|https://user-images.githubusercontent.com/10044588/177236335-03418698-1f83-4bb0-8215-ebf4149d74f9.mp4|



