### PR TITLE
[After #96] fix: android font fallback

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,0 @@
-/Users/takerusato/fvm/versions/3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 .idea/
 .dart_tool/
+
+#fvm related
+fvm
+.fvm/flutter_sdk

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "dart.flutterSdkPath": ".fvm/flutter_sdk",
+  "dart.sdkPath": ".fvm/flutter_sdk/bin/dart",
   "editor.formatOnSave": false,
   "dart.allowAnalytics": false,
   "dart.enableSdkFormatter": false,

--- a/packages/zefyr/example/android/app/build.gradle
+++ b/packages/zefyr/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.zefyr.example"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/zefyr/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/zefyr/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -14,6 +14,7 @@
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:exported="true"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/packages/zefyr/example/android/build.gradle
+++ b/packages/zefyr/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/zefyr/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/zefyr/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://downloads.gradle-dn.com/distributions/gradle-7.0.2-bin.zip

--- a/packages/zefyr/example/pubspec.yaml
+++ b/packages/zefyr/example/pubspec.yaml
@@ -54,6 +54,13 @@ flutter:
   assets:
     - assets/
     - images/breeze.jpg
+  fonts:
+    - family: Noto Sans JP
+      fonts:
+        - asset: packages/zefyr/fonts/NotoSansJP-Regular.otf
+          weight: 400
+        - asset: packages/zefyr/fonts/NotoSansJP-Bold.otf
+          weight: 700
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg

--- a/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
+++ b/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
@@ -11,8 +11,9 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
 
   @override
   set textEditingValue(TextEditingValue value) {
-    widget.controller
-        .updateSelection(value.selection, source: ChangeSource.local);
+    // NOTE: Flutter 3 から TextSelectionDelegate から
+    // textEditingValue の setter がなくなったので、中身はuserUpdateTextEditingValueで実装する
+    userUpdateTextEditingValue(value, SelectionChangedCause.drag);
   }
 
   @override
@@ -78,7 +79,9 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) async {
-    // NOTE: もはやここは呼ばれないがないと怒られるので
+    // NOTE: causeは今のところ使っていない
+    widget.controller
+        .updateSelection(value.selection, source: ChangeSource.local);
   }
 
   @override

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:notus/notus.dart';
 import 'package:zefyr/util.dart';
 
@@ -188,9 +187,7 @@ class TextLine extends StatelessWidget {
       textStyle = textStyle.merge(theme.lists.style);
     }
 
-    return textStyle.merge(TextStyle(
-      fontFamilyFallback: [GoogleFonts.workSans().fontFamily!],
-    ));
+    return textStyle;
   }
 
   TextStyle _getInlineTextStyle(NotusStyle style, ZefyrThemeData theme) {

--- a/packages/zefyr/lib/src/widgets/text_selection.dart
+++ b/packages/zefyr/lib/src/widgets/text_selection.dart
@@ -356,21 +356,29 @@ class EditorTextSelectionOverlay {
 
   void _handleSelectionHandleChanged(
       TextSelection newSelection, _TextSelectionHandlePosition position) {
-    late TextPosition textPosition;
-    switch (position) {
-      case _TextSelectionHandlePosition.start:
-        textPosition = newSelection.base;
-        break;
-      case _TextSelectionHandlePosition.end:
-        textPosition = newSelection.extent;
-        break;
-    }
-    // ignore: deprecated_member_use
+
+    // bringIntoView がいまのところ実装されていないためコメントアウト
+    // late TextPosition textPosition;
+    // switch (position) {
+    //   case _TextSelectionHandlePosition.start:
+    //     textPosition = newSelection.base;
+    //     break;
+    //   case _TextSelectionHandlePosition.end:
+    //     textPosition = newSelection.extent;
+    //     break;
+    // }
+
+    // 長さが0になる場合に挙動が不安定なので、最低1は確保するようにする
+    final selection = newSelection.baseOffset == newSelection.extentOffset ?
+    newSelection.copyWith(extentOffset: newSelection.extentOffset + 1) : newSelection;
+
     selectionDelegate!.userUpdateTextEditingValue(
-      _value.copyWith(selection: newSelection, composing: TextRange.empty),
+      _value.copyWith(selection: selection, composing: TextRange.empty),
       SelectionChangedCause.keyboard,
     );
-    selectionDelegate!.bringIntoView(textPosition);
+
+    // bringIntoView はいまのところ実装されていない
+    // selectionDelegate!.bringIntoView(textPosition);
   }
 }
 

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -5,9 +5,16 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 final TextStyle baseStyle = TextStyle(
-  fontFamily: Platform.isIOS ? 'Hiragino Kaku Gothic ProN' : 'Noto Sans JP'
+  fontFamily: Platform.isIOS ? 'Hiragino Kaku Gothic ProN' : 'Noto Sans JP',
+  fontFamilyFallback: [
+    GoogleFonts.notoSans().fontFamily!,
+    ...(GoogleFonts.notoSans().fontFamilyFallback ?? []),
+    GoogleFonts.workSans().fontFamily!,
+    GoogleFonts.inter().fontFamily!,
+  ],
 );
 
 // final TextStyle baseStyle = GoogleFonts.notoSans();


### PR DESCRIPTION
# Why
フォント変更に伴なって、Androidで一部特殊文字が文字化けしていたため

# What
- baseStyle に fontFallback を設定 b1eedfe0397234401a8410632bce8e1a57804d4b
- （おまけ）zefyr/example で Noto Sans JP を使えるように設定 1b98a74ea535395fa95e0e6e5b0d7617e9dc2ce9

# Demo
|before|after|
|--|--|
|![CleanShot 2022-07-05 at 12 38 11@2x](https://user-images.githubusercontent.com/10044588/177244978-e929296a-95ab-4a0e-abc4-b5812ba76c6f.png)|![CleanShot 2022-07-05 at 12 34 41@2x](https://user-images.githubusercontent.com/10044588/177244987-59312012-c19f-4947-9d87-85ba99c1f93a.png)|