### PR TITLE
Override new functions in TextInputClient

### DIFF
--- a/.github/workflows/test_zefyr.yml
+++ b/.github/workflows/test_zefyr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v1
         with:
-          flutter-version: "3.0.1"
+          flutter-version: "3.7.12"
 
       - name: Test zefyr
         run: |

--- a/packages/zefyr/.fvm/fvm_config.json
+++ b/packages/zefyr/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.0.1",
+  "flutterSdkVersion": "3.7.12",
   "flavors": {}
 }

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -6,6 +6,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:zefyr/src/widgets/baseline_proxy.dart';
 
 import '../../zefyr.dart';
@@ -1265,6 +1266,22 @@ class RawEditorState extends EditorState
   @override
   void removeTextPlaceholder() {
     // TODO: implement removeTextPlaceholder
+  }
+
+  @override
+  void didChangeInputControl(
+      TextInputControl? oldControl, TextInputControl? newControl) {
+    /*
+    The framework calls this method to notify that the text input control has been changed.
+    The TextInputClient may switch to the new text input control by hiding the old and showing the new input control.
+    */
+  }
+
+  @override
+  void performSelector(String selectorName) {
+    /*
+    Performs the specified MacOS-specific selector from the NSStandardKeyBindingResponding protocol or user-specified selector from DefaultKeyBinding.Dict.
+    */
   }
 }
 


### PR DESCRIPTION
## 🎫 TICKET
- [riverpod v2 対応](https://www.notion.so/hokuto/riverpod-v2-ea84c194f8114dad8e3e1af541acc8ca)

## 🎩 WHY
- Riverpod v2の恩恵をフルに受けるにはFlutterのバージョンを更新する必要がある
- Flutterのバージョンを更新するにはzefyrに修正が必要

## 🌈 WHAT
TextInputClientにoverrideが必要なメソッドが増えたので、追加

## 📸 DEMO
🙅

## 📱 QA
🙅