### PR TITLE
Migrate to Flutter 3.10

### DIFF
--- a/.github/workflows/test_zefyr.yml
+++ b/.github/workflows/test_zefyr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v1
         with:
-          flutter-version: "3.7.12"
+          flutter-version: "3.10.6"
 
       - name: Test zefyr
         run: |

--- a/packages/zefyr/.fvm/fvm_config.json
+++ b/packages/zefyr/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.7.12",
+  "flutterSdkVersion": "3.10.6",
   "flavors": {}
 }

--- a/packages/zefyr/example/ios/Podfile
+++ b/packages/zefyr/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/zefyr/example/ios/Podfile.lock
+++ b/packages/zefyr/example/ios/Podfile.lock
@@ -1,34 +1,35 @@
 PODS:
   - Flutter (1.0.0)
-  - image_picker (0.0.1):
+  - image_picker_ios (0.0.1):
     - Flutter
-  - path_provider_ios (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - image_picker (from `.symlinks/plugins/image_picker/ios`)
-  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  image_picker:
-    :path: ".symlinks/plugins/image_picker/ios"
-  path_provider_ios:
-    :path: ".symlinks/plugins/path_provider_ios/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  image_picker: 66aa71bc96850a90590a35d4c4a2907b0d823109
-  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
-  url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
+  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
-PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.12.1

--- a/packages/zefyr/example/lib/src/editor_page.dart
+++ b/packages/zefyr/example/lib/src/editor_page.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:example/src/loading.dart';
 import 'package:flutter/material.dart';
 import 'package:quill_delta/quill_delta.dart';
 import 'package:zefyr/zefyr.dart';
@@ -12,10 +13,10 @@ class EditorPage extends StatefulWidget {
 
 class EditorPageState extends State<EditorPage> {
   /// Allows to control the editor and the document.
-  ZefyrController _controller;
+  ZefyrController? _controller;
 
   /// Zefyr editor like any other input field requires a focus node.
-  FocusNode _focusNode;
+  late final FocusNode _focusNode;
 
   @override
   void initState() {
@@ -30,13 +31,8 @@ class EditorPageState extends State<EditorPage> {
 
   @override
   Widget build(BuildContext context) {
-    final body = (_controller == null)
-        ? Center(child: CircularProgressIndicator())
-        : ZefyrField(
-            padding: EdgeInsets.all(16),
-            controller: _controller,
-            focusNode: _focusNode,
-          );
+    final controller = _controller; 
+    if (controller == null) return Loading();
 
     return Scaffold(
       appBar: AppBar(
@@ -45,12 +41,16 @@ class EditorPageState extends State<EditorPage> {
           Builder(
             builder: (context) => IconButton(
               icon: Icon(Icons.save),
-              onPressed: () => _saveDocument(context),
+              onPressed: () => _saveDocument(context, controller),
             ),
           )
         ],
       ),
-      body: body,
+      body: ZefyrField(
+        padding: EdgeInsets.all(16),
+        controller: _controller!,
+        focusNode: _focusNode,
+      ),
     );
   }
 
@@ -68,10 +68,10 @@ class EditorPageState extends State<EditorPage> {
     return NotusDocument()..compose(delta, ChangeSource.local);
   }
 
-  void _saveDocument(BuildContext context) {
+  void _saveDocument(BuildContext context, ZefyrController controller) {
     // Notus documents can be easily serialized to JSON by passing to
     // `jsonEncode` directly:
-    final contents = jsonEncode(_controller.document);
+    final contents = jsonEncode(controller.document);
     // For this example we save our document to a temporary file.
     final file = File(Directory.systemTemp.path + '/quick_start.json');
     // And show a snack bar on success.

--- a/packages/zefyr/example/lib/src/full_page.dart
+++ b/packages/zefyr/example/lib/src/full_page.dart
@@ -42,7 +42,7 @@ class _FullPageEditorScreenState extends State<FullPageEditorScreen> {
       ZefyrController(NotusDocument.fromJson(json.decode(doc)));
   final FocusNode _focusNode = FocusNode();
   bool _editing = false;
-  StreamSubscription<NotusChange> _sub;
+  late final StreamSubscription<NotusChange> _sub;
   bool _darkTheme = false;
 
   @override
@@ -91,7 +91,8 @@ class _FullPageEditorScreenState extends State<FullPageEditorScreen> {
     return Theme(data: ThemeData(primarySwatch: Colors.cyan), child: result);
   }
 
-  void _launchUrl(String url) async {
+  void _launchUrl(String? url) async {
+    if (url == null) return;
     final uri = Uri.tryParse(url);
     if (uri == null) return;
     if (await canLaunchUrl(uri)) {

--- a/packages/zefyr/example/lib/src/layout.dart
+++ b/packages/zefyr/example/lib/src/layout.dart
@@ -12,11 +12,11 @@ bool isDisplaySmallDesktop(BuildContext context) {
 }
 
 class PageLayout extends StatefulWidget {
-  final Widget appBar;
+  final PreferredSizeWidget appBar;
   final Widget menuBar;
   final Widget body;
 
-  const PageLayout({Key key, this.appBar, this.menuBar, this.body})
+  const PageLayout({Key? key, required this.appBar, required this.menuBar, required this.body})
       : super(key: key);
 
   @override
@@ -43,7 +43,7 @@ class _DesktopScaffold extends StatelessWidget {
   final Widget menuBar;
   final Widget body;
 
-  const _DesktopScaffold({Key key, this.appBar, this.menuBar, this.body})
+  const _DesktopScaffold({Key? key, required this.appBar, required this.menuBar, required this.body})
       : super(key: key);
   @override
   Widget build(BuildContext context) {
@@ -74,11 +74,11 @@ class _DesktopScaffold extends StatelessWidget {
 }
 
 class _MobileScaffold extends StatelessWidget {
-  final Widget appBar;
+  final PreferredSizeWidget appBar;
   final Widget menuBar;
   final Widget body;
 
-  const _MobileScaffold({Key key, this.appBar, this.menuBar, this.body})
+  const _MobileScaffold({Key? key, required this.appBar, required this.menuBar, required this.body})
       : super(key: key);
 
   @override

--- a/packages/zefyr/example/lib/src/loading.dart
+++ b/packages/zefyr/example/lib/src/loading.dart
@@ -1,0 +1,16 @@
+
+import 'package:flutter/material.dart';
+
+class Loading extends StatelessWidget {
+
+  const Loading({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Loading...'),
+      ),
+    );
+  }
+}

--- a/packages/zefyr/example/lib/src/scaffold.dart
+++ b/packages/zefyr/example/lib/src/scaffold.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:example/src/loading.dart';
 import 'package:file/local.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -15,14 +16,14 @@ class DemoScaffold extends StatefulWidget {
   /// Filename of the document to load into the editor.
   final String documentFilename;
   final DemoContentBuilder builder;
-  final List<Widget> actions;
-  final Widget floatingActionButton;
+  final List<Widget>? actions;
+  final Widget? floatingActionButton;
   final bool showToolbar;
 
   const DemoScaffold({
-    Key key,
-    @required this.documentFilename,
-    @required this.builder,
+    Key? key,
+    required this.documentFilename,
+    required this.builder,
     this.actions,
     this.showToolbar = true,
     this.floatingActionButton,
@@ -34,7 +35,7 @@ class DemoScaffold extends StatefulWidget {
 
 class _DemoScaffoldState extends State<DemoScaffold> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  ZefyrController _controller;
+  ZefyrController? _controller;
 
   bool _loading = false;
   bool _canSave = false;
@@ -105,13 +106,16 @@ class _DemoScaffoldState extends State<DemoScaffold> {
     final file = fs
         .directory(settings.assetsPath)
         .childFile('${widget.documentFilename}');
-    final data = jsonEncode(_controller.document);
+    final data = jsonEncode(_controller!.document);
     await file.writeAsString(data);
-    ScaffoldMessenger.of(_scaffoldKey.currentState.context).showSnackBar(SnackBar(content: Text('Saved.')));
+    ScaffoldMessenger.of(_scaffoldKey.currentState!.context).showSnackBar(SnackBar(content: Text('Saved.')));
   }
 
   @override
   Widget build(BuildContext context) {
+    final controller = _controller;
+    if (controller == null) return Loading();
+
     final actions = widget.actions ?? <Widget>[];
     if (_canSave) {
       actions.add(IconButton(
@@ -123,6 +127,7 @@ class _DemoScaffoldState extends State<DemoScaffold> {
         ),
       ));
     }
+
     return Scaffold(
       key: _scaffoldKey,
       appBar: AppBar(
@@ -138,15 +143,13 @@ class _DemoScaffoldState extends State<DemoScaffold> {
           ),
           onPressed: () => Navigator.pop(context),
         ),
-        title: _loading || widget.showToolbar == false
+        title: widget.showToolbar == false
             ? null
-            : ZefyrToolbar.basic(controller: _controller),
+            : ZefyrToolbar.basic(controller: controller),
         actions: actions,
       ),
       floatingActionButton: widget.floatingActionButton,
-      body: _loading
-          ? Center(child: Text('Loading...'))
-          : widget.builder(context, _controller),
+      body: widget.builder(context, controller),
     );
   }
 }

--- a/packages/zefyr/example/lib/src/settings.dart
+++ b/packages/zefyr/example/lib/src/settings.dart
@@ -11,7 +11,7 @@ class Settings {
   /// application can be saved back to the assets folder.
   final String assetsPath;
 
-  Settings({this.assetsPath});
+  Settings({required this.assetsPath});
 
   static Future<Settings> load() async {
     if (kIsWeb) {
@@ -32,7 +32,7 @@ class Settings {
   static Settings of(BuildContext context) {
     final widget =
         context.dependOnInheritedWidgetOfExactType<SettingsProvider>();
-    return widget.settings;
+    return widget!.settings;
   }
 
   Future<void> save() async {
@@ -47,7 +47,7 @@ class Settings {
   }
 }
 
-Future<Settings> showSettingsDialog(BuildContext context, Settings settings) {
+Future<Settings?> showSettingsDialog(BuildContext context, Settings settings) {
   return showDialog<Settings>(
       context: context, builder: (ctx) => SettingsDialog(settings: settings));
 }
@@ -55,7 +55,7 @@ Future<Settings> showSettingsDialog(BuildContext context, Settings settings) {
 class SettingsDialog extends StatefulWidget {
   final Settings settings;
 
-  const SettingsDialog({Key key, @required this.settings}) : super(key: key);
+  const SettingsDialog({Key? key, required this.settings}) : super(key: key);
 
   @override
   _SettingsDialogState createState() => _SettingsDialogState();
@@ -63,7 +63,7 @@ class SettingsDialog extends StatefulWidget {
 
 class _SettingsDialogState extends State<SettingsDialog> {
   String _assetsPath = '';
-  TextEditingController _assetsPathController;
+  late TextEditingController _assetsPathController;
 
   @override
   void initState() {
@@ -111,7 +111,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
 class SettingsProvider extends InheritedWidget {
   final Settings settings;
 
-  SettingsProvider({Key key, this.settings, Widget child})
+  SettingsProvider({Key? key, required this.settings, required Widget child})
       : super(key: key, child: child);
 
   @override

--- a/packages/zefyr/example/lib/src/text_field_page.dart
+++ b/packages/zefyr/example/lib/src/text_field_page.dart
@@ -5,7 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:zefyr/zefyr.dart';
 
 class TextFieldScreen extends StatefulWidget {
-  TextFieldScreen({Key key, this.title}) : super(key: key);
+  TextFieldScreen({Key? key, required this.title}) : super(key: key);
 
   final String title;
 
@@ -14,7 +14,7 @@ class TextFieldScreen extends StatefulWidget {
 }
 
 class _TextFieldScreenState extends State<TextFieldScreen> {
-  ZefyrController _controller;
+  late ZefyrController _controller;
   final FocusNode _focusNode = FocusNode();
 
   @override
@@ -67,7 +67,8 @@ class _TextFieldScreenState extends State<TextFieldScreen> {
     );
   }
 
-  void _launchUrl(String url) async {
+  void _launchUrl(String? url) async {
+    if (url == null) return;
     final uri = Uri.tryParse(url);
     if (uri == null) return;
     final result = await canLaunchUrl(uri);

--- a/packages/zefyr/example/pubspec.yaml
+++ b/packages/zefyr/example/pubspec.yaml
@@ -22,8 +22,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-  image_picker: ^0.6.1
+  image_picker: ^1.0.1
   url_launcher: ^6.0.9
   adaptive_breakpoints: ^0.0.3
   google_fonts: 4.0.3

--- a/packages/zefyr/example/pubspec.yaml
+++ b/packages/zefyr/example/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.9.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/packages/zefyr/example/pubspec.yaml
+++ b/packages/zefyr/example/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   image_picker: ^0.6.1
   url_launcher: ^6.0.9
   adaptive_breakpoints: ^0.0.3
-  google_fonts: 2.2.0
+  google_fonts: 4.0.3
   file: ^6.1.2
   path_provider: ^2.0.2
   zefyr:

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -23,6 +23,9 @@ import 'text_selection.dart';
 typedef ZefyrEmbedBuilder = Widget Function(
     BuildContext context, EmbedNode node);
 
+typedef DragSelectionUpdateCallback = void Function(
+    DragStartDetails startDetails, DragUpdateDetails updateDetails);
+
 /// Default implementation of a builder function for embeddable objects in
 /// Zefyr.
 ///
@@ -31,7 +34,8 @@ Widget defaultZefyrEmbedBuilder(BuildContext context, EmbedNode node) {
   if (node.value.type == 'hr') {
     final theme = ZefyrTheme.of(context)!;
     return Divider(
-      height: (theme.paragraph.style.fontSize ?? 0.0) * (theme.paragraph.style.height ?? 0.0),
+      height: (theme.paragraph.style.fontSize ?? 0.0) *
+          (theme.paragraph.style.height ?? 0.0),
       thickness: 2,
       color: Colors.grey.shade200,
     );
@@ -171,7 +175,8 @@ class ZefyrEditor extends StatefulWidget {
   /// Callback to invoke when user wants to launch a URL.
   final ValueChanged<String>? onLaunchUrl;
 
-  final void Function(EmbeddableObject, {required bool readOnly})? onTapEmbedObject;
+  final void Function(EmbeddableObject, {required bool readOnly})?
+      onTapEmbedObject;
 
   /// Builder function for embeddable objects.
   ///
@@ -219,7 +224,8 @@ class _ZefyrEditorState extends State<ZefyrEditor>
   @override
   bool get selectionEnabled => widget.enableInteractiveSelection;
 
-  late EditorTextSelectionGestureDetectorBuilder _selectionGestureDetectorBuilder;
+  late EditorTextSelectionGestureDetectorBuilder
+      _selectionGestureDetectorBuilder;
 
   void _requestKeyboard() {
     _editorKey.currentState?.requestKeyboard();
@@ -378,14 +384,16 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
     final line = result!.node as LineNode;
     if (line.hasEmbed) {
       final embed = line.children.single as EmbedNode;
-      editor?.widget.onTapEmbedObject?.call(embed.value, readOnly: _state.widget.readOnly);
+      editor?.widget.onTapEmbedObject
+          ?.call(embed.value, readOnly: _state.widget.readOnly);
     }
     final segmentResult = line.lookup(result.offset);
     if (segmentResult.node == null) return;
     final segment = segmentResult.node as LeafNode;
     if (segment.style.contains(NotusAttribute.link) &&
         editor?.widget.onLaunchUrl != null) {
-      editor?.widget.onLaunchUrl!(segment.style.get(NotusAttribute.link)!.value!);
+      editor
+          ?.widget.onLaunchUrl!(segment.style.get(NotusAttribute.link)!.value!);
     }
   }
 
@@ -408,6 +416,7 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
               renderEditor?.selectPosition(cause: SelectionChangedCause.tap);
               break;
             case PointerDeviceKind.touch:
+            case PointerDeviceKind.trackpad:
             case PointerDeviceKind.unknown:
               // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
               // of the word.
@@ -521,7 +530,8 @@ class RawEditor extends StatefulWidget {
   /// a link in the document.
   final ValueChanged<String>? onLaunchUrl;
 
-  final void Function(EmbeddableObject, {required bool readOnly})? onTapEmbedObject;
+  final void Function(EmbeddableObject, {required bool readOnly})?
+      onTapEmbedObject;
 
   /// Configuration of toolbar options.
   ///
@@ -727,7 +737,8 @@ class RawEditorState extends EditorState
   ///
   /// This property is typically used to notify the renderer of input gestures.
   @override
-  RenderEditor get renderEditor => _editorKey.currentContext!.findRenderObject() as RenderEditor;
+  RenderEditor get renderEditor =>
+      _editorKey.currentContext!.findRenderObject() as RenderEditor;
 
   /// Express interest in interacting with the keyboard.
   ///
@@ -1057,13 +1068,15 @@ class RawEditorState extends EditorState
     await Future.delayed(const Duration(milliseconds: 100));
     final viewport = RenderAbstractViewport.of(renderEditor);
     if (viewport == null || _searchFocus == null) return;
-    final editorOffset = renderEditor.localToGlobal(Offset(0.0, 0.0), ancestor: viewport);
+    final editorOffset =
+        renderEditor.localToGlobal(Offset(0.0, 0.0), ancestor: viewport);
     final offsetInViewport = _scrollController!.offset + editorOffset.dy;
     final offset = renderEditor.getSelectionOffset(
       _scrollController!.position.viewportDimension,
       _scrollController!.offset,
       offsetInViewport,
-      TextSelection(baseOffset: _searchFocus!.end, extentOffset: _searchFocus!.end),
+      TextSelection(
+          baseOffset: _searchFocus!.end, extentOffset: _searchFocus!.end),
     );
     if (offset == null) return;
     await _scrollController!.animateTo(
@@ -1282,6 +1295,11 @@ class RawEditorState extends EditorState
     /*
     Performs the specified MacOS-specific selector from the NSStandardKeyBindingResponding protocol or user-specified selector from DefaultKeyBinding.Dict.
     */
+  }
+
+  @override
+  void insertContent(KeyboardInsertedContent content) {
+    // TODO: implement insertContent
   }
 }
 

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -837,7 +837,7 @@ class RawEditorState extends EditorState
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final parentTheme = ZefyrTheme.of(context, nullOk: true);
+    final parentTheme = ZefyrTheme.maybeOf(context);
     final fallbackTheme = ZefyrThemeData.fallback(context);
     _themeData = (parentTheme != null)
         ? fallbackTheme.merge(parentTheme)

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -53,12 +53,18 @@ class ZefyrTheme extends InheritedWidget {
   /// Returns `null` if there is no [ZefyrTheme] in the given build context
   /// and [nullOk] is set to `true`. If [nullOk] is set to `false` (default)
   /// then this method asserts.
-  static ZefyrThemeData? of(BuildContext context, {bool nullOk = false}) {
+  static ZefyrThemeData? maybeOf(BuildContext context) {
     final widget = context.dependOnInheritedWidgetOfExactType<ZefyrTheme>();
-    if (widget == null && nullOk) return null;
-    assert(widget != null,
-        '$ZefyrTheme.of() called with a context that does not contain a ZefyrEditor.');
-    return widget!.data;
+    return widget?.data;
+  }
+
+  static ZefyrThemeData of(BuildContext context) {
+    final widget = context.dependOnInheritedWidgetOfExactType<ZefyrTheme>();
+    if (widget == null) {
+      
+      throw AssertionError('$ZefyrTheme.of() called with a context that does not contain a ZefyrEditor.');
+    }
+    return widget.data;
   }
 }
 

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
       path: packages/notus
   quiver_hashcode: ^3.0.0+1
   characters: ^1.0.0
-  google_fonts: 2.2.0
+  google_fonts: 4.0.3
   validators: ^3.0.0
   kana_kit: ^2.0.0
 


### PR DESCRIPTION
- Override new functions in TextInputClient
- Declare func type that remove from the framework (`DragSelectionUpdateCallback`)
- Modify according to of and maybeOf naming rules (`ZefyrThemeData`)