### PR TITLE
一番上だったらどんなstyleでもトップはデフォルトスペースで固定

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1190,7 +1190,7 @@ class RawEditorState extends EditorState
           node: node,
           textDirection: _textDirection,
           indentWidth: _indentWidth(node, _themeData),
-          spacing: _getSpacingForLine(node, _themeData),
+          spacing: _getSpacingForLine(node, _themeData, result.isEmpty),
           cursorController: _cursorController,
           selection: widget.controller.selection,
           selectionColor: widget.selectionColor,
@@ -1213,7 +1213,7 @@ class RawEditorState extends EditorState
         result.add(EditableTextBlock(
           node: node,
           textDirection: _textDirection,
-          spacing: _getSpacingForBlock(node, _themeData),
+          spacing: _getSpacingForBlock(node, _themeData, result.isEmpty),
           cursorController: _cursorController,
           selection: widget.controller.selection,
           selectionColor: widget.selectionColor,
@@ -1236,7 +1236,10 @@ class RawEditorState extends EditorState
     return result;
   }
 
-  VerticalSpacing _getSpacingForLine(LineNode node, ZefyrThemeData theme) {
+  VerticalSpacing _getSpacingForLine(LineNode node, ZefyrThemeData theme, bool useDefault) {
+    if (useDefault) {
+      return theme.paragraph.spacing;
+    }
     final style = node.style.get(NotusAttribute.heading);
     if (style == NotusAttribute.heading.level1) {
       return theme.heading1.spacing;
@@ -1251,7 +1254,10 @@ class RawEditorState extends EditorState
     }
   }
 
-  VerticalSpacing _getSpacingForBlock(BlockNode node, ZefyrThemeData theme) {
+  VerticalSpacing _getSpacingForBlock(BlockNode node, ZefyrThemeData theme, bool useDefault) {
+    if (useDefault) {
+      return theme.paragraph.spacing;
+    }
     final style = node.style.get(NotusAttribute.block);
     if (style == NotusAttribute.block.code) {
       return theme.code.spacing;


### PR DESCRIPTION
[Zefyrの一番上はマージン固定する](https://www.notion.so/hokuto/024955dda9a342f9a438112903ab4ce2?p=140d439c6436480e8082a485fa117d58&pm=s)

|h1|h2|h3|image|
|-|-|-|-|
|![Simulator Screenshot - iPhone 14 - 2023-07-31 at 13 38 57](https://github.com/hokutoresident/zefyr/assets/34063746/f2feb417-251a-4c6b-9b15-204d41a9a936)|![Simulator Screenshot - iPhone 14 - 2023-07-31 at 13 39 01](https://github.com/hokutoresident/zefyr/assets/34063746/cd926ea8-a26e-4404-81c6-416eceaef378)|![Simulator Screenshot - iPhone 14 - 2023-07-31 at 13 39 03](https://github.com/hokutoresident/zefyr/assets/34063746/2d387f95-8b6f-4934-962c-283d5117a702)|![Simulator Screenshot - iPhone 14 - 2023-07-31 at 13 39 15](https://github.com/hokutoresident/zefyr/assets/34063746/04ef3d6a-8479-4c77-88a3-b812d3f45d99)|

# QA
- [x] 冒頭はH1でもプレーンテキストでも同じマージン
- [x] 冒頭以外はいつも通りスタイルごとにマージンは変化する