### PR TITLE
isEndNewLineでエラーが発生しうるケースのハンドリング

### DIFF
--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -296,7 +296,14 @@ class ZefyrController extends ChangeNotifier {
   // ノート最後尾が改行で終わっているか
   bool isEndNewline() {
     final wholeText = document.toPlainText();
+      if (wholeText.isEmpty) {
+      return false; // 文字列が空の場合、改行で終わらないと判断
+    }
+
     final lastIndex = wholeText.length - 1;
+    if (lastIndex < 1) {
+      return false; // 文字列が1文字しかない場合、連続する改行で終わることはない
+    }
     final lastChar = wholeText[lastIndex];
     final secondLastChar = wholeText[lastIndex - 1];
     final endsNewLine = lastChar == '\n' && secondLastChar == '\n';

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -301,10 +301,10 @@ class ZefyrController extends ChangeNotifier {
     }
 
     final lastIndex = wholeText.length - 1;
-    if (lastIndex < 1) {
-      return false; // 文字列が1文字しかない場合、連続する改行で終わることはない
-    }
     final lastChar = wholeText[lastIndex];
+    if (wholeText.length == 1) {
+      return lastChar == '\n'; // 文字列が1文字しかない場合、その文字が改行コードかどうかを返す
+    }
     final secondLastChar = wholeText[lastIndex - 1];
     final endsNewLine = lastChar == '\n' && secondLastChar == '\n';
     return endsNewLine;


### PR DESCRIPTION
### WHY
(どうやって該当するノートを作るのかはわかっていないが、) isEndNewLineで 
`RangeError (index): Invalid value: Only valid value is 0: -1` を発生させているユーザーがいたので、その対応


### WHAT
配列の参照時に添え字で0未満の数値が入るとエラーが出るので、0未満になりそうだったら早期returnを行う