### PR TITLE
refactor  _showSearchFocus

### DIFF
--- a/packages/zefyr/example/ios/Podfile.lock
+++ b/packages/zefyr/example/ios/Podfile.lock
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  image_picker_ios: b545a5f16c0fa88e3ecbbce3ed4de45567a8ec18
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  url_launcher_ios: 6116280ddcfe98ab8820085d8d76ae7449447586
+  image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
+  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.15.2

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -38,7 +38,8 @@ class ZefyrController extends ChangeNotifier {
   int searchFocusIndex = -1;
   final onChangeSearchFocus = StreamController<Match>.broadcast();
   final onChangeSearchQuery = StreamController<String>.broadcast();
-  final onChangeSearchFocusTop = StreamController<Match>.broadcast();
+  // Matchに対してスクロールしたいときに呼びだされるStreamController
+  final scrollToMatchStream = StreamController<Match>.broadcast();
 
   final uiExceptionStream = StreamController<Object>.broadcast();
 
@@ -234,7 +235,7 @@ class ZefyrController extends ChangeNotifier {
     document.close();
     onChangeSearchFocus.close();
     onChangeSearchQuery.close();
-    onChangeSearchFocusTop.close();
+    scrollToMatchStream.close();
     uiExceptionStream.close();
     super.dispose();
   }


### PR DESCRIPTION
## サマリ
「zefyr内の検索処理」と同じ機構を使っているコンテンツ内ジャンプリンクの実装のために作られた処理について、
実際結合する必要のない処理があったので、処理を分割した

## 具体的にしたこと
- onChangeSearchFocusTop を scrollToMatchStream にrename
- コンテンツ内ジャンプリンクのための処理では `setState(() { _searchFocus = focus; });` を実行しないように変更
- _showSearchFocus のうち、「スクロールに関する処理」をscrollToSelection(TextSelection ) に変更
- 