### PR TITLE
improve(removeNewlineAtLast)空のZefyrに対して関数を走らせないように PRODUCT-1682

### DIFF
--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -288,6 +288,8 @@ class ZefyrController extends ChangeNotifier {
 
   // ノート最後尾から改行を削除
   void removeNewlineAtLast() {
+    final wholeText = document.toPlainText();
+    if (wholeText.isEmpty || wholeText == '\n') return;
     if (!isEndNewline()) return;
     replaceText(
       document.length - 1,

--- a/packages/zefyr/test/widgets/controller_test.dart
+++ b/packages/zefyr/test/widgets/controller_test.dart
@@ -202,11 +202,22 @@ void main() {
       controller.removeNewlineAtLast();
       expect(controller.isEndNewline(), isFalse);
     });
-
+    // controller.document.toPlainText()時には自動で改行が入る
     test('removeNewlineAtLast - 最後が改行でない場合は何もしない', () {
       controller.replaceText(0, 0, 'words');
       expect(controller.isEndNewline(), isFalse);
       controller.removeNewlineAtLast();
+      expect(controller.document.toPlainText(), 'words\n');
+    });
+    test('removeNewlineAtLast - 空文字の場合は何もしない', () {
+      controller.replaceText(0, 0, '');
+      controller.removeNewlineAtLast();
+      expect(controller.document.toPlainText(), '\n');
+    });
+      test('removeNewlineAtLast - １改行のみの場合は何もしない', () {
+      controller.replaceText(0, 0, '\n');
+      controller.removeNewlineAtLast();
+      expect(controller.document.toPlainText(), '\n');
     });
 
     test('updateSelectionAtLast', () {


### PR DESCRIPTION
[improve(controller)最後の行から改行を消したい #112](https://github.com/hokutoresident/zefyr/pull/112)で対応した内容に対しての修正です。
以下のように内容が空の時にこの関数を走らせてしまうと``` Failed assertion: line 213 pos 12: 'firstChild != null': is not true.```とzefyr内部のエラーが発生してしまいます。ユーザー体験に特に影響はないです
（[スレッド](https://hokutohq.slack.com/archives/CL0STNCGG/p1725840002808899)）
![スクリーンショット 2024-10-02 15 58 39](https://github.com/user-attachments/assets/f5bef6b0-a7b5-4dee-8fec-3815aad563ce)
